### PR TITLE
Upgrade io-ts and fp-ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "cors": "^2.8.4",
     "dotenv": "^6.0.0",
     "express": "^4.16.2",
-    "fp-ts": "^1.8.1",
+    "fp-ts": "1.17.4",
     "helmet": "^3.21.1",
     "helmet-csp": "^2.9.3",
-    "io-ts": "^1.3.0",
+    "io-ts": "^1.8.5",
     "italia-ts-commons": "^2.14.0",
     "json-set-map": "^1.0.2",
     "memoizee": "^0.4.14",
@@ -81,5 +81,8 @@
     "tslint-immutable": "^4.4.0",
     "tslint-plugin-prettier": "^2.0.1",
     "typescript": "^3.0.1"
+  },
+  "resolutions": {
+    "fp-ts": "1.17.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1602,15 +1602,10 @@ forwarded@~0.1.2:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
-fp-ts@1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-1.12.0.tgz#d333310e4ac104cdcb6bea47908e381bb09978e7"
-  integrity sha512-fWwnAgVlTsV26Ruo9nx+fxNHIm6l1puE1VJ/C0XJ3nRQJJJIgRHYw6sigB3MuNFZL1o4fpGlhwFhcbxHK0RsOA==
-
-fp-ts@^1.0.0, fp-ts@^1.6.0, fp-ts@^1.8.1:
-  version "1.19.5"
-  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-1.19.5.tgz#3da865e585dfa1fdfd51785417357ac50afc520a"
-  integrity sha512-wDNqTimnzs8QqpldiId9OavWK2NptormjXnRJTQecNjzwfyp6P/8s/zG8e4h3ja3oqkKaY72UlTjQYt/1yXf9A==
+fp-ts@1.12.0, fp-ts@1.17.4, fp-ts@^1.0.0, fp-ts@^1.6.0:
+  version "1.17.4"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-1.17.4.tgz#f41eeeb2a8924b51b11521f93f5f59d28d0503be"
+  integrity sha512-OaIM5w0FceJm6zO0OjMY05Rdg02nlFCpilTrMitzGnHORh/8neP0NH9OcRvnGQdOEh2T5xjtcutzzctvWOQtCQ==
 
 frameguard@3.1.0:
   version "3.1.0"
@@ -1995,7 +1990,7 @@ io-ts@1.8.5:
   dependencies:
     fp-ts "^1.0.0"
 
-io-ts@^1.1.4, io-ts@^1.3.0:
+io-ts@^1.1.4, io-ts@^1.8.5:
   version "1.10.4"
   resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-1.10.4.tgz#cd5401b138de88e4f920adbcb7026e2d1967e6e2"
   integrity sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==


### PR DESCRIPTION
The goal of this PR is to update the following dependencies:
- io-ts -> 1.8.5
- fp-ts -> 1.17.4