### PR TITLE
[#175892280] Fix decoder body response 201 and update max logo size

### DIFF
--- a/src/api_client.ts
+++ b/src/api_client.ts
@@ -129,7 +129,7 @@ export type UploadServiceLogoT = IPutApiRequestType<
   },
   OcpApimSubscriptionKey | "Content-Type",
   never,
-  ApiResponseType<undefined>
+  ApiResponseType<{}>
 >;
 
 export type UploadOrganizationLogoT = IPutApiRequestType<
@@ -139,7 +139,7 @@ export type UploadOrganizationLogoT = IPutApiRequestType<
   },
   OcpApimSubscriptionKey | "Content-Type",
   never,
-  ApiResponseType<undefined>
+  ApiResponseType<{}>
 >;
 
 export function APIClient(
@@ -212,7 +212,7 @@ export function APIClient(
     headers: composeHeaderProducers(tokenHeaderProducer, ApiHeaderJson),
     method: "put",
     query: _ => ({}),
-    response_decoder: apiResponseDecoder(t.undefined),
+    response_decoder: apiResponseDecoder(t.type({})),
     url: params => `/adm/services/${params.serviceId}/logo`
   };
 
@@ -221,7 +221,7 @@ export function APIClient(
     headers: composeHeaderProducers(tokenHeaderProducer, ApiHeaderJson),
     method: "put",
     query: _ => ({}),
-    response_decoder: apiResponseDecoder(t.undefined),
+    response_decoder: apiResponseDecoder(t.type({})),
     url: params => `/adm/organizations/${params.organizationfiscalcode}/logo`
   };
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -87,8 +87,8 @@ secureExpressApp(app);
 
 app.use(cors());
 app.use(cookieParser());
-app.use(bodyParser.urlencoded({ extended: true, limit: "50mb" }));
-app.use(bodyParser.json({ limit: "50mb" }));
+app.use(bodyParser.urlencoded({ extended: true, limit: "5mb" }));
+app.use(bodyParser.json({ limit: "5mb" }));
 app.use(passport.initialize());
 app.use(morgan("combined"));
 
@@ -242,7 +242,7 @@ app.get(
 
 app.get("/configuration", toExpressHandler(getConfiguration));
 
-const port = config.port || 3000;
+const port = config.port || 3999;
 app.listen(port);
 
 logger.debug("Listening on port %s", port.toString());

--- a/src/app.ts
+++ b/src/app.ts
@@ -87,7 +87,7 @@ secureExpressApp(app);
 
 app.use(cors());
 app.use(cookieParser());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.urlencoded({ extended: true, limit: "50mb" }));
 app.use(bodyParser.json());
 app.use(passport.initialize());
 app.use(morgan("combined"));

--- a/src/app.ts
+++ b/src/app.ts
@@ -88,7 +88,7 @@ secureExpressApp(app);
 app.use(cors());
 app.use(cookieParser());
 app.use(bodyParser.urlencoded({ extended: true, limit: "50mb" }));
-app.use(bodyParser.json());
+app.use(bodyParser.json({ limit: "50mb" }));
 app.use(passport.initialize());
 app.use(morgan("combined"));
 

--- a/src/middlewares/upload_logo.ts
+++ b/src/middlewares/upload_logo.ts
@@ -115,7 +115,7 @@ export const uploadOrganizationLogoTask = (
           ? taskEither.of(
               ResponseSuccessRedirectToResource(
                 {},
-                `${config.logoUrl}/services/${organizationfiscalcode}.png`,
+                `${config.logoUrl}/organizations/${organizationfiscalcode}.png`,
                 {}
               )
             )


### PR DESCRIPTION
This PR introduces:
- fix api response decoder for 201, decoding a empty body with `{}` instead `undefined`
- update max logo size to 50 mb