### PR TITLE
update privacy policy - take 2

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -1,19 +1,24 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="it">
 
 <head>
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-  <link href="//fonts.googleapis.com/css?family=Titillium+Web:400,400italic,700," rel="stylesheet" type="text/css" />
-  <link href="//italia.github.io/design-web-toolkit/build/build.css" rel="stylesheet" media="all" type="text/css" />
+  <link href="//fonts.googleapis.com/css?family=Titillium+Web:400,400italic,700," rel="stylesheet" type="text/css"/>
+  <link href="//italia.github.io/design-web-toolkit/build/build.css" rel="stylesheet" media="all" type="text/css"/>
+  <link href="//pagopa.github.io/io-developer-portal-backend/global.css" rel="stylesheet" media="all" type="text/css"/>
+  
+  <style>
+      ul, ol {
+          list-style: initial;
+          margin-left: 20px;
+      }
+      </style>
 
-  <link href="//teamdigitale.github.io/io-developer-portal-backend/global.css" rel="stylesheet" media="all" type="text/css"
-  />
-  <!-- <link href="./global.css" rel="stylesheet" media="all" type="text/css" /> -->
-
-  <title>Digital Citizenship API</title>
+  <title>Privacy Policy</title>
+  
 </head>
 
 <body>
@@ -22,60 +27,236 @@
       <h1>Privacy Policy</h1>
       <div>
         <p>
-          In questa pagina si descrivono le modalità e le condizioni del trattamento dei dati personali degli utenti che consultano
-          e utilizzano il sito <a href="https://developer.cd.italia.it">https://developer.cd.italia.it</a> (di seguito anche il Sito).
+        La presente informativa descrive le modalità del trattamento dei dati personali degli
+        utenti (di seguito gli “Utenti”) che consultano il portale raggiungibile all’indirizzo
+        <a href="https://developer.io.italia.it">developer.io.italia.it</a> (di seguito il
+        "Portale").
         </p>
         <p>
-          L’informativa è resa ai sensi dell’<a href="http://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:2003-06-30;196">
-          art. 13 del D. Lgs. n. 196/2003 - Codice in materia di protezione dei dati personali</a> a
-          tutti gli Utenti che, interagendo con il Sito, forniscono al gestore dello stesso i propri dati personali. La validità
-          dell’informativa contenuta nella presente pagina è limitata al solo Sito e non si estende ad altri siti web eventualmente
-          consultabili mediante collegamento ipertestuale. Il Titolare del trattamento per i dati raccolti attraverso il
-          Sito è AgID - Agenzia per l’Italia Digitale, con sede in via Liszt 21 - 00144 Roma, indirizzo email info@agid.gov.it.
-          Eventuali soggetti terzi ai quali i dati potrebbero essere comunicati per l’esecuzione di operazioni di trattamento
-          connesse con le finalità specificate nella presente informativa, saranno preventivamente designati dal Titolare
-          quali Responsabili del trattamento ai sensi dell’art. 29 del Codice in materia di protezione dei dati personali.
-          Tutti i dati personali forniti attraverso il Sito saranno trattati in modo lecito e secondo correttezza al fine
-          di fornire i servizi richiesti nonché di rispondere alle comunicazioni ed alle domande degli Utenti, sempre nel
-          perseguimento degli scopi istituzionali dell’Agenzia così come previsti dalla Legge. I dati personali sono trattati
-          con strumenti automatizzati per il tempo strettamente necessario a conseguire gli scopi per cui sono stati raccolti
-          secondo quanto previsto dall’art. 11, lett. e) del Codice privacy.
+        L’informativa è resa ai sensi dell’art. 13 del
+        <a ref="https://eur-lex.europa.eu/legal-content/IT/TXT/HTML/?uri=CELEX:32016R0679#d1e2261-1-1">Regolamento (UE) 2016/679</a>
+        (di seguito il “Regolamento”). La validità dell’informativa contenuta nella presente pagina
+        è limitata al solo Portale e non si estende ad altri siti web eventualmente consultabili
+        mediante collegamento ipertestuale.
         </p>
-        <h2>Tipologie di Dati raccolti</h2>
+        <br>
         <p>
-          Dati personali raccolti da questa applicazione: nome, cognome, email e sede di lavoro dell'utente, forniti liberamente al
-          momento della registrazione al portale sviluppatori. Tutti i campi sono obbligatori e, laddove non forniti, l'applicazione
-          non può erogare correttamente il servizio.
+        <h3>Data protection officer (DPO) o Responsabile Protezione Dati (RPD)</h3>
+        La società PagoPA Spa ha nominato un proprio Responsabile della Protezione dei dati, ai
+        sensi dell’art. 37 del Regolamento UE 2016/679, che può essere contattato ai seguenti
+        recapiti:
+        <ul>
+            <li>mail: <a href="mailto:dpo@pagopa.it">dpo@pagopa.it</a>;</li>
+            <li>PEC: <a href="mailto:dpo@pec.pagopa.it">dpo@pec.pagopa.it</a>;</li>
+            <li>indirizzo: Via Sardegna n. 38 - 00187, ROMA (sede operativa della società)</li>
+        </ul>
         </p>
+        <br>
+<h3>Titolare del trattamento</h3>
         <p>
-          L’Agenzia adotta tutte le misure di sicurezza previste dal Codice privacy per proteggere i dati raccolti, al fine di scongiurare
-          i rischi di perdita o furto dei dati, accessi non autorizzati, usi illeciti e non corretti. Gli Utenti possono
-          esercitare in qualsiasi momento i diritti previsti dall’art. 7 del Codice privacy, al fine di ottenere la conferma
-          dell’esistenza o meno dei loro dati personali e di conoscerne il contenuto e l’origine, verificarne l’esattezza
-          o chiederne l’integrazione o l’aggiornamento, oppure la rettificazione. Ai sensi della medesima disposizione l’Utente
-          potrà inoltre chiedere la cancellazione, la trasformazione in forma anonima o il blocco dei dati trattati in violazione
-          di legge, nonché opporsi in ogni caso, per motivi legittimi, al loro trattamento. Le richieste vanno inviate al
-          seguente indirizzo: <a href="mailto:info@agid.gov.it">info@agid.gov.it</a>. 
-          Attraverso il medesimo indirizzo, l’Utente potrà chiedere inoltre la lista
-          aggiornata di tutti i Responsabili del trattamento nominati dal Titolare.
+      Il Titolare del trattamento è la società PagoPA SpA, con sede in Roma, Piazza Colonna 370,
+      CAP 00187 - n. di iscrizione a Registro Imprese di Roma, CF e P.IVA 15376371009, email <a href="mailto:info@pagopa.it">info@pagopa.it</a>.
         </p>
+        <br>
         <p>
-          La presente Privacy Policy è soggetta ad aggiornamenti; gli Utenti sono pertanto invitati a verificarne periodicamente il
-          contenuto.
+<h3> Categorie di dati trattati</h3>
+    <h4> a) Dati relativi agli identificatori online e alla navigazione</h4>
+        <p>
+        I sistemi informatici preposti al funzionamento del Portale acquisiscono, nel corso del
+        loro normale esercizio, alcuni dati personali la cui trasmissione è implicita nell’uso dei
+        protocolli di comunicazione di Internet.
         </p>
         <p>
-          <h2>Cookies policy</h2>
-          <p>
-            I cookies sono piccoli file di testo che i siti visitati inviano al terminale dell’Utente, dove vengono memorizzati, per
-            poi essere ritrasmessi agli stessi siti alla visita successiva. L’eventuale utilizzo di Cookie - o di altri strumenti
-            di tracciamento - da parte di questa Applicazione o dei titolari dei servizi terzi utilizzati da questa Applicazione,
-            ove non diversamente precisato, ha la finalità di fornire il servizio richiesto dall'Utente. I cookies utilizzati
-            dal Sito non consentono la raccolta di informazioni personali relative all’utente e si cancellano automaticamente
-            con la chiusura del browser di navigazione. I cookies non sono utilizzati per attività di profilazione dell’Utente.
-            L’Utente può scegliere di abilitare o disabilitare i cookies intervenendo sulle impostazioni del proprio browser
-            di navigazione secondo le istruzioni rese disponibili dai relativi fornitori.
-          </p>
+        In questa categoria di dati rientrano gli indirizzi IP o i nomi a dominio dispositivi
+        utilizzati dagli Utenti, gli indirizzi in notazione URI/URL (Uniform Resource
+        Identifier/Locator) delle risorse richieste, l’orario della richiesta, il tipo di richiesta
+        effettuata (risorsa richiesta e nome dell’operazione), il metodo utilizzato nel sottoporre
+        la richiesta al server, la dimensione del file ottenuto in risposta, il codice numerico
+        indicante lo stato della risposta data dal server (buon fine, errore, ecc.) ed altri
+        parametri relativi al sistema operativo e all’ambiente informatico dell’Utente.
         </p>
+        <p>
+        A ciascun utente, i sistemi del Portale attribuiscono un codice identificativo univoco
+        associato all’account e conservato nei log.
+        </p>
+        <p>
+        Tali dati, necessari per la fruizione dei servizi del Portale, vengono anche trattati allo
+        scopo di controllare il corretto funzionamento dei sistemi e dei servizi offerti dal
+        Portale (diagnostica) e per motivi di sicurezza.
+        </p>
+        <br
+        <p>
+    <h4> b) Dati forniti volontariamente dall’Utente</h4>
+        </p>
+        <p>
+        Il Titolare acquisirà i dati personali forniti volontariamente dall’Utente per la creazione
+        e la gestione del proprio account, e in particolare:
+        </p>
+        <ul>
+           <li>cognome e nome, display name, codice fiscale, dati relativi all’attività lavorativa
+               svolta (Ente/Società, Dipartimento/Ufficio, nome del Servizio), indirizzo di posta
+               elettronica, numero di telefono mobile;</li>
+           <li>credenziali di accesso (indirizzo di posta elettronica e password) degli Utenti, in
+               quanto necessari all’accesso al Portale.</li>
+        </ul>
+        <p>
+        Tutti i campi sono obbligatori e, laddove non forniti, il Portale non può erogare
+        correttamente il servizio.
+        </p>
+        <br>
+        <p>
+    <h4>c) Cookies</h4>
+        </p>
+        <p>
+        I cookies sono piccoli file di testo che i siti visitati inviano al terminale dell’Utente,
+        dove vengono memorizzati, per poi essere ritrasmessi agli stessi siti alla visita
+        successiva.
+        </p>
+        Il Portale utilizza esclusivamente cookies di autenticazione e di sessione al fine di
+        consentire all’Utente l’accesso e l’autenticazione (login) al Portale. Quando si esegue
+        l’accesso al Portale, viene generato e archiviato un numero di ID univoco e l’orario di
+        accesso in cookie crittografati nel dispositivo dell’Utente. Tali cookies sono necessari
+        per l’autenticazione e consente all’Utente di spostarsi tra le pagine del Portale,
+        all’interno di una sessione autenticata, senza dover effettuare nuovamente l’autenticazione
+        a ogni pagina del Portale stesso durante la navigazione.
+        </p>
+        <p>
+        I cookies non sono utilizzati per attività di profilazione dell’Utente. Tali cookies
+        vengono utilizzati dal Portale unicamente se l’Utente effettua il login al Portale stesso,
+        e vengono conservati fino al termine della sessione browser.
+        </p>
+        <p>
+        L’Utente può scegliere di abilitare e disabilitare i cookies intervenendo sulle
+        impostazioni del proprio browser di navigazione secondo le istruzioni rese disponibili dai
+        relativi fornitori ai link di seguito indicati.
+        </p>
+        <ul>
+            <li><a href:"https://support.google.com/chrome/answer/95647?co=GENIE.Platform%3DDesktop&hl=it">Chrome</a></li>
+           <li><a href:"https://support.mozilla.org/it/kb/Attivare%20e%20disattivare%20i%20cookie">Firefox</a></li>
+           <li><a href:"https://support.apple.com/kb/ph19214?locale=it_IT">Safari</a></li>
+           <li><a href:"https://support.microsoft.com/it-it/help/17442/windows-internet-explorer-delete-manage-cookies"> Internet Explorer</a></li>
+           <li><a href:"https://support.microsoft.com/it-it/help/4027947/windows-delete-cookies">Edge</a></li>
+           <li><a href:"https://help.opera.com/en/latest/web-preferences/#cookies">Opera</a></li>
+        </ul>
+        </p>
+        <p>
+        Qualora l’Utente disabiliti i cookies di autenticazione, non potrà accedere, autenticarsi o
+        navigare nel Portale e dunque il servizio non potrà essere erogato.
+        </p>
+        <br>
+        <p>
+<h3>Base giuridica del trattamento</h3>
+        <ul>
+            <li>Il trattamento è necessario per lo svolgimento dei compiti istituzionali attribuiti
+                al Titolare del trattamento sulla base dell’art. 8 del decreto-legge 14 dicembre
+                2018, n. 135 (convertito, con modificazioni, dalla legge 11 febbraio 2019, n. 12),
+                e dunque per l’esecuzione di un compito di interesse pubblico, previsto dalla
+                legge, o connesso all’esercizio di pubblici poteri di cui è investito il Titolare
+                del trattamento, (art. 6, comma 1, lettere c) ed e) del Regolamento),  in
+                particolare con riferimento allo sviluppo e alla gestione del progetto IO.</li>
+            <li>Il trattamento è necessario ai fini della stipula e dell’esecuzione di un
+                contratto, ovvero ai fini dell’esecuzione di misure precontrattuali adottate su
+                richiesta dell’interessato (art. 6, comma 1, lettera b) del Regolamento).</li>
+            <li>Il trattamento può essere basato sul consenso dell’Utente che richiede
+                volontariamente di iscriversi al Portale per effettuare test (art. 6, comma 1,
+                lett. a) del Regolamento).</li>
+        </ul>
+        <br>
+        <p>
+<h3>Finalità del trattamento</h3>
+        </p>
+        <p>
+        I dati degli Utenti sono raccolti per le seguenti finalità:
+        </p>
+        <ul>
+            <li>permettere a un Utente di:
+                <ul>
+                    <li>effettuare test, contribuire al miglioramento del Portale e della
+                        Piattaforma IO;</li>
+                    <li>modificare i dati dei Servizi;</li>
+                    <li>ottenere le chiavi di autenticazione (API Key) per ogni Servizio al fine di
+                        attivare i Servizi dell’Ente;</li>
+                    <li>gestire la composizione dei Messaggi e delle schede servizio per ciascun
+                        Servizio dell'Ente attivato dagli Utenti;</li>
+                    <li>utilizzare ogni altra funzionalità prevista e disponibile per gli Utenti
+                        nel Portale.</li>
+                </ul>
+                <li>identificare gli Utenti che utilizzano il Portale in qualità di Delegati degli
+                    Enti;</li>
+                <li>permettere agli amministratori di sistema di svolgere tutte le funzioni di
+                    amministrazione, compresa la gestione dei permessi degli Utenti per motivi di
+                    sicurezza.</li>
+        </ul>
+        <p>
+        I dati relativi agli identificatori online e alla navigazione sono raccolti altresì per
+        necessità legate al funzionamento, alla manutenzione e alla sicurezza del Portale.
+        </p>
+        <p>
+        I dati personali dell’Utente possono essere utilizzati dal Titolare in giudizio o nelle
+        fasi propedeutiche alla sua eventuale instaurazione per la difesa da abusi perpetrati
+        dall’Utente.
+        </p>
+        <p>
+        L’Utente è consapevole che il Titolare potrebbe dover comunicare i dati personali trattati,
+        su richiesta delle pubbliche Autorità.
+        </p>
+        <p>
+        Gli Utenti possono ottenere chiarimenti sulla finalità della raccolta dei dati o su quali
+        dati siano effettivamente acquisiti, contattando il Titolare.
+        </p>
+        <br>
+        <p>
+<h3>Categorie di soggetti ai quali i dati personali possono essere comunicati</h3>
+        Il Titolare potrà comunicare, per il perseguimento delle finalità sopra indicate, alcuni
+        dati personali anche a:
+        <ul>
+            <li>soggetti terzi che forniscono un servizio al Titolare stesso e che tratteranno i
+                dati personali in qualità di responsabili del trattamento;</li>
+            <li>altri soggetti terzi, pubblici o privati, che ne facciano richiesta alla PagoPA SpA
+                per l’esecuzione di un compito di interesse pubblico o connesso all’esercizio di un
+                pubblico potere o per adempiere a un obbligo legale.</li>
+        </ul>
+        I destinatari sono nominati, ove richiesto dalla normativa, Responsabili del trattamento da
+        parte del Titolare. L’elenco dei responsabili del trattamento può essere richiesto al
+        Titolare in qualsiasi momento, scrivendo a <a href:"mailtodpo@pagopa.it">dpo@pagopa.it</a>
+        </p>
+        <br>
+        <p>
+<h3>Trasferimento dati fuori dall’UE</h3>
+        Alcuni dei fornitori terzi che utilizziamo risiedono negli USA. Abbiamo concluso con tali
+        fornitori accordi di servizio ai sensi dell’art. 28 del Regolamento. Tutti i fornitori sono
+        conformi al Regolamento e, in assenza di altre misure di garanzia previste dal Regolamento,
+        abbiamo concluso con loro le Clausole Contrattuali della Commissione Europea per garantire
+        adeguati livelli di tutela. Una copia delle garanzie poste in essere può essere richiesta
+        in qualsiasi momento, scrivendo a <a href:"dpo@pagopa.it">dpo@pagopa.it</a>
+        </p>
+        <br>
+        <p>
+<h3>Tempi di conservazione dei dati</h3>
+        I dati personali raccolti saranno conservati per per il periodo di tempo necessario
+        all’utilizzo del Portale da parte dell’Utente, anche ove contrattualmente determinato.
+        Resta salvo il trattamento fondato su altra base giuridica, ivi inclusa quella di fare
+        fronte a eventuali contestazioni o contenziosi, e in tal caso i dati verranno
+        successivamente trattati conformemente a quanto previsto dagli obblighi di legge. Per
+        maggiori informazioni è possibile scrivere a <a href:"dpo@pagopa.it">dpo@pagopa.it</a>
+        </p>
+        <br>
+        <p>
+<h3>Diritti degli interessati</h3>
+        Gli interessati hanno il diritto di ottenere, nei casi previsti, l’accesso ai propri dati
+        personali e la rettifica o la cancellazione degli stessi o la limitazione del trattamento
+        che li riguarda o di opporsi al trattamento (artt. 15 e ss. del Regolamento). Tali
+        richieste potranno essere indirizzate al Titolare, scrivendo a <a href:"dpo@pagopa.it">dpo@pagopa.it</a>
+        </p>
+        <br>
+        <p>
+<h3>Diritti di reclamo</h3>
+        Gli interessati che ritengono che il trattamento dei dati personali a loro riferiti,
+        effettuato attraverso il Portale avvenga in violazione di quanto previsto dal Regolamento
+        hanno il diritto di proporre reclamo al Garante, come previsto dall’art. 77 del Regolamento
+        stesso, o di adire le opportune sedi giudiziarie (art. 79 del Regolamento).
+        </p>
+
       </div>
     </div>
 

--- a/privacy.html
+++ b/privacy.html
@@ -1,266 +1,271 @@
 <!DOCTYPE html>
 <html lang="it">
-
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-  <link href="//fonts.googleapis.com/css?family=Titillium+Web:400,400italic,700," rel="stylesheet" type="text/css"/>
-  <link href="//italia.github.io/design-web-toolkit/build/build.css" rel="stylesheet" media="all" type="text/css"/>
-  <link href="//pagopa.github.io/io-developer-portal-backend/global.css" rel="stylesheet" media="all" type="text/css"/>
-  
-  <style>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link href="//fonts.googleapis.com/css?family=Titillium+Web:400,400italic,700," rel="stylesheet" type="text/css"/>
+    <link href="//italia.github.io/design-web-toolkit/build/build.css" rel="stylesheet" media="all" type="text/css"/>
+    <link href="//pagopa.github.io/io-developer-portal-backend/global.css" rel="stylesheet" media="all" type="text/css"/>
+    <style>
       ul, ol {
-          list-style: initial;
-          margin-left: 20px;
+      list-style: initial;
+      margin-left: 20px;
       }
-      </style>
-
-  <title>Privacy Policy</title>
-  
-</head>
-
-<body>
-  <div class="container">
-    <div class="privacyPolicy">
-      <h1>Privacy Policy</h1>
-      <div>
-        <p>
-        La presente informativa descrive le modalità del trattamento dei dati personali degli
-        utenti (di seguito gli “Utenti”) che consultano il portale raggiungibile all’indirizzo
-        <a href="https://developer.io.italia.it">developer.io.italia.it</a> (di seguito il
-        "Portale").
-        </p>
-        <p>
-        L’informativa è resa ai sensi dell’art. 13 del
-        <a ref="https://eur-lex.europa.eu/legal-content/IT/TXT/HTML/?uri=CELEX:32016R0679#d1e2261-1-1">Regolamento (UE) 2016/679</a>
-        (di seguito il “Regolamento”). La validità dell’informativa contenuta nella presente pagina
-        è limitata al solo Portale e non si estende ad altri siti web eventualmente consultabili
-        mediante collegamento ipertestuale.
-        </p>
-        <br>
-        <p>
-        <h3>Data protection officer (DPO) o Responsabile Protezione Dati (RPD)</h3>
-        La società PagoPA Spa ha nominato un proprio Responsabile della Protezione dei dati, ai
-        sensi dell’art. 37 del Regolamento UE 2016/679, che può essere contattato ai seguenti
-        recapiti:
-        <ul>
+    </style>
+    <title>Privacy Policy</title>
+  </head>
+  <body>
+    <div class="container">
+      <div class="privacyPolicy">
+        <h1>Privacy Policy</h1>
+        <div>
+          <p>
+            La presente informativa descrive le modalità del trattamento dei dati personali degli
+            utenti (di seguito gli “Utenti”) che consultano il portale raggiungibile all’indirizzo
+            <a href="https://developer.io.italia.it">developer.io.italia.it</a> (di seguito il
+            "Portale").
+          </p>
+          <p>
+            L’informativa è resa ai sensi dell’art. 13 del
+            <a ref="https://eur-lex.europa.eu/legal-content/IT/TXT/HTML/?uri=CELEX:32016R0679#d1e2261-1-1">Regolamento (UE) 2016/679</a>
+            (di seguito il “Regolamento”). La validità dell’informativa contenuta nella presente pagina
+            è limitata al solo Portale e non si estende ad altri siti web eventualmente consultabili
+            mediante collegamento ipertestuale.
+          </p>
+          <br>
+          <p>
+          <h3>Data protection officer (DPO) o Responsabile Protezione Dati (RPD)</h3>
+          La società PagoPA Spa ha nominato un proprio Responsabile della Protezione dei dati, ai
+          sensi dell’art. 37 del Regolamento UE 2016/679, che può essere contattato ai seguenti
+          recapiti:
+          <ul>
             <li>mail: <a href="mailto:dpo@pagopa.it">dpo@pagopa.it</a>;</li>
             <li>PEC: <a href="mailto:dpo@pec.pagopa.it">dpo@pec.pagopa.it</a>;</li>
             <li>indirizzo: Via Sardegna n. 38 - 00187, ROMA (sede operativa della società)</li>
-        </ul>
-        </p>
-        <br>
-<h3>Titolare del trattamento</h3>
-        <p>
-      Il Titolare del trattamento è la società PagoPA SpA, con sede in Roma, Piazza Colonna 370,
-      CAP 00187 - n. di iscrizione a Registro Imprese di Roma, CF e P.IVA 15376371009, email <a href="mailto:info@pagopa.it">info@pagopa.it</a>.
-        </p>
-        <br>
-        <p>
-<h3> Categorie di dati trattati</h3>
-    <h4> a) Dati relativi agli identificatori online e alla navigazione</h4>
-        <p>
-        I sistemi informatici preposti al funzionamento del Portale acquisiscono, nel corso del
-        loro normale esercizio, alcuni dati personali la cui trasmissione è implicita nell’uso dei
-        protocolli di comunicazione di Internet.
-        </p>
-        <p>
-        In questa categoria di dati rientrano gli indirizzi IP o i nomi a dominio dispositivi
-        utilizzati dagli Utenti, gli indirizzi in notazione URI/URL (Uniform Resource
-        Identifier/Locator) delle risorse richieste, l’orario della richiesta, il tipo di richiesta
-        effettuata (risorsa richiesta e nome dell’operazione), il metodo utilizzato nel sottoporre
-        la richiesta al server, la dimensione del file ottenuto in risposta, il codice numerico
-        indicante lo stato della risposta data dal server (buon fine, errore, ecc.) ed altri
-        parametri relativi al sistema operativo e all’ambiente informatico dell’Utente.
-        </p>
-        <p>
-        A ciascun utente, i sistemi del Portale attribuiscono un codice identificativo univoco
-        associato all’account e conservato nei log.
-        </p>
-        <p>
-        Tali dati, necessari per la fruizione dei servizi del Portale, vengono anche trattati allo
-        scopo di controllare il corretto funzionamento dei sistemi e dei servizi offerti dal
-        Portale (diagnostica) e per motivi di sicurezza.
-        </p>
-        <br
-        <p>
-    <h4> b) Dati forniti volontariamente dall’Utente</h4>
-        </p>
-        <p>
-        Il Titolare acquisirà i dati personali forniti volontariamente dall’Utente per la creazione
-        e la gestione del proprio account, e in particolare:
-        </p>
-        <ul>
-           <li>cognome e nome, display name, codice fiscale, dati relativi all’attività lavorativa
-               svolta (Ente/Società, Dipartimento/Ufficio, nome del Servizio), indirizzo di posta
-               elettronica, numero di telefono mobile;</li>
-           <li>credenziali di accesso (indirizzo di posta elettronica e password) degli Utenti, in
-               quanto necessari all’accesso al Portale.</li>
-        </ul>
-        <p>
-        Tutti i campi sono obbligatori e, laddove non forniti, il Portale non può erogare
-        correttamente il servizio.
-        </p>
-        <br>
-        <p>
-    <h4>c) Cookies</h4>
-        </p>
-        <p>
-        I cookies sono piccoli file di testo che i siti visitati inviano al terminale dell’Utente,
-        dove vengono memorizzati, per poi essere ritrasmessi agli stessi siti alla visita
-        successiva.
-        </p>
-        Il Portale utilizza esclusivamente cookies di autenticazione e di sessione al fine di
-        consentire all’Utente l’accesso e l’autenticazione (login) al Portale. Quando si esegue
-        l’accesso al Portale, viene generato e archiviato un numero di ID univoco e l’orario di
-        accesso in cookie crittografati nel dispositivo dell’Utente. Tali cookies sono necessari
-        per l’autenticazione e consente all’Utente di spostarsi tra le pagine del Portale,
-        all’interno di una sessione autenticata, senza dover effettuare nuovamente l’autenticazione
-        a ogni pagina del Portale stesso durante la navigazione.
-        </p>
-        <p>
-        I cookies non sono utilizzati per attività di profilazione dell’Utente. Tali cookies
-        vengono utilizzati dal Portale unicamente se l’Utente effettua il login al Portale stesso,
-        e vengono conservati fino al termine della sessione browser.
-        </p>
-        <p>
-        L’Utente può scegliere di abilitare e disabilitare i cookies intervenendo sulle
-        impostazioni del proprio browser di navigazione secondo le istruzioni rese disponibili dai
-        relativi fornitori ai link di seguito indicati.
-        </p>
-        <ul>
+          </ul>
+          </p>
+          <br>
+          <h3>Titolare del trattamento</h3>
+          <p>
+            Il Titolare del trattamento è la società PagoPA SpA, con sede in Roma, Piazza Colonna 370,
+            CAP 00187 - n. di iscrizione a Registro Imprese di Roma, CF e P.IVA 15376371009, email <a href="mailto:info@pagopa.it">info@pagopa.it</a>.
+          </p>
+          <br>
+          <p>
+          <h3> Categorie di dati trattati</h3>
+          <h4> a) Dati relativi agli identificatori online e alla navigazione</h4>
+          <p>
+            I sistemi informatici preposti al funzionamento del Portale acquisiscono, nel corso del
+            loro normale esercizio, alcuni dati personali la cui trasmissione è implicita nell’uso dei
+            protocolli di comunicazione di Internet.
+          </p>
+          <p>
+            In questa categoria di dati rientrano gli indirizzi IP o i nomi a dominio dispositivi
+            utilizzati dagli Utenti, gli indirizzi in notazione URI/URL (Uniform Resource
+            Identifier/Locator) delle risorse richieste, l’orario della richiesta, il tipo di richiesta
+            effettuata (risorsa richiesta e nome dell’operazione), il metodo utilizzato nel sottoporre
+            la richiesta al server, la dimensione del file ottenuto in risposta, il codice numerico
+            indicante lo stato della risposta data dal server (buon fine, errore, ecc.) ed altri
+            parametri relativi al sistema operativo e all’ambiente informatico dell’Utente.
+          </p>
+          <p>
+            A ciascun utente, i sistemi del Portale attribuiscono un codice identificativo univoco
+            associato all’account e conservato nei log.
+          </p>
+          <p>
+            Tali dati, necessari per la fruizione dei servizi del Portale, vengono anche trattati allo
+            scopo di controllare il corretto funzionamento dei sistemi e dei servizi offerti dal
+            Portale (diagnostica) e per motivi di sicurezza.
+          </p>
+          <br
+          <p>
+          <h4> b) Dati forniti volontariamente dall’Utente</h4>
+          </p>
+          <p>
+            Il Titolare acquisirà i dati personali forniti volontariamente dall’Utente per la creazione
+            e la gestione del proprio account, e in particolare:
+          </p>
+          <ul>
+            <li>cognome e nome, display name, codice fiscale, dati relativi all’attività lavorativa
+              svolta (Ente/Società, Dipartimento/Ufficio, nome del Servizio), indirizzo di posta
+              elettronica, numero di telefono mobile;
+            </li>
+            <li>credenziali di accesso (indirizzo di posta elettronica e password) degli Utenti, in
+              quanto necessari all’accesso al Portale.
+            </li>
+          </ul>
+          <p>
+            Tutti i campi sono obbligatori e, laddove non forniti, il Portale non può erogare
+            correttamente il servizio.
+          </p>
+          <br>
+          <p>
+          <h4>c) Cookies</h4>
+          </p>
+          <p>
+            I cookies sono piccoli file di testo che i siti visitati inviano al terminale dell’Utente,
+            dove vengono memorizzati, per poi essere ritrasmessi agli stessi siti alla visita
+            successiva.
+          </p>
+          Il Portale utilizza esclusivamente cookies di autenticazione e di sessione al fine di
+          consentire all’Utente l’accesso e l’autenticazione (login) al Portale. Quando si esegue
+          l’accesso al Portale, viene generato e archiviato un numero di ID univoco e l’orario di
+          accesso in cookie crittografati nel dispositivo dell’Utente. Tali cookies sono necessari
+          per l’autenticazione e consente all’Utente di spostarsi tra le pagine del Portale,
+          all’interno di una sessione autenticata, senza dover effettuare nuovamente l’autenticazione
+          a ogni pagina del Portale stesso durante la navigazione.
+          </p>
+          <p>
+            I cookies non sono utilizzati per attività di profilazione dell’Utente. Tali cookies
+            vengono utilizzati dal Portale unicamente se l’Utente effettua il login al Portale stesso,
+            e vengono conservati fino al termine della sessione browser.
+          </p>
+          <p>
+            L’Utente può scegliere di abilitare e disabilitare i cookies intervenendo sulle
+            impostazioni del proprio browser di navigazione secondo le istruzioni rese disponibili dai
+            relativi fornitori ai link di seguito indicati.
+          </p>
+          <ul>
             <li><a href:"https://support.google.com/chrome/answer/95647?co=GENIE.Platform%3DDesktop&hl=it">Chrome</a></li>
-           <li><a href:"https://support.mozilla.org/it/kb/Attivare%20e%20disattivare%20i%20cookie">Firefox</a></li>
-           <li><a href:"https://support.apple.com/kb/ph19214?locale=it_IT">Safari</a></li>
-           <li><a href:"https://support.microsoft.com/it-it/help/17442/windows-internet-explorer-delete-manage-cookies"> Internet Explorer</a></li>
-           <li><a href:"https://support.microsoft.com/it-it/help/4027947/windows-delete-cookies">Edge</a></li>
-           <li><a href:"https://help.opera.com/en/latest/web-preferences/#cookies">Opera</a></li>
-        </ul>
-        </p>
-        <p>
-        Qualora l’Utente disabiliti i cookies di autenticazione, non potrà accedere, autenticarsi o
-        navigare nel Portale e dunque il servizio non potrà essere erogato.
-        </p>
-        <br>
-        <p>
-<h3>Base giuridica del trattamento</h3>
-        <ul>
+            <li><a href:"https://support.mozilla.org/it/kb/Attivare%20e%20disattivare%20i%20cookie">Firefox</a></li>
+            <li><a href:"https://support.apple.com/kb/ph19214?locale=it_IT">Safari</a></li>
+            <li><a href:"https://support.microsoft.com/it-it/help/17442/windows-internet-explorer-delete-manage-cookies"> Internet Explorer</a></li>
+            <li><a href:"https://support.microsoft.com/it-it/help/4027947/windows-delete-cookies">Edge</a></li>
+            <li><a href:"https://help.opera.com/en/latest/web-preferences/#cookies">Opera</a></li>
+          </ul>
+          </p>
+          <p>
+            Qualora l’Utente disabiliti i cookies di autenticazione, non potrà accedere, autenticarsi o
+            navigare nel Portale e dunque il servizio non potrà essere erogato.
+          </p>
+          <br>
+          <p>
+          <h3>Base giuridica del trattamento</h3>
+          <ul>
             <li>Il trattamento è necessario per lo svolgimento dei compiti istituzionali attribuiti
-                al Titolare del trattamento sulla base dell’art. 8 del decreto-legge 14 dicembre
-                2018, n. 135 (convertito, con modificazioni, dalla legge 11 febbraio 2019, n. 12),
-                e dunque per l’esecuzione di un compito di interesse pubblico, previsto dalla
-                legge, o connesso all’esercizio di pubblici poteri di cui è investito il Titolare
-                del trattamento, (art. 6, comma 1, lettere c) ed e) del Regolamento),  in
-                particolare con riferimento allo sviluppo e alla gestione del progetto IO.</li>
+              al Titolare del trattamento sulla base dell’art. 8 del decreto-legge 14 dicembre
+              2018, n. 135 (convertito, con modificazioni, dalla legge 11 febbraio 2019, n. 12),
+              e dunque per l’esecuzione di un compito di interesse pubblico, previsto dalla
+              legge, o connesso all’esercizio di pubblici poteri di cui è investito il Titolare
+              del trattamento, (art. 6, comma 1, lettere c) ed e) del Regolamento),  in
+              particolare con riferimento allo sviluppo e alla gestione del progetto IO.
+            </li>
             <li>Il trattamento è necessario ai fini della stipula e dell’esecuzione di un
-                contratto, ovvero ai fini dell’esecuzione di misure precontrattuali adottate su
-                richiesta dell’interessato (art. 6, comma 1, lettera b) del Regolamento).</li>
+              contratto, ovvero ai fini dell’esecuzione di misure precontrattuali adottate su
+              richiesta dell’interessato (art. 6, comma 1, lettera b) del Regolamento).
+            </li>
             <li>Il trattamento può essere basato sul consenso dell’Utente che richiede
-                volontariamente di iscriversi al Portale per effettuare test (art. 6, comma 1,
-                lett. a) del Regolamento).</li>
-        </ul>
-        <br>
-        <p>
-<h3>Finalità del trattamento</h3>
-        </p>
-        <p>
-        I dati degli Utenti sono raccolti per le seguenti finalità:
-        </p>
-        <ul>
-            <li>permettere a un Utente di:
-                <ul>
-                    <li>effettuare test, contribuire al miglioramento del Portale e della
-                        Piattaforma IO;</li>
-                    <li>modificare i dati dei Servizi;</li>
-                    <li>ottenere le chiavi di autenticazione (API Key) per ogni Servizio al fine di
-                        attivare i Servizi dell’Ente;</li>
-                    <li>gestire la composizione dei Messaggi e delle schede servizio per ciascun
-                        Servizio dell'Ente attivato dagli Utenti;</li>
-                    <li>utilizzare ogni altra funzionalità prevista e disponibile per gli Utenti
-                        nel Portale.</li>
-                </ul>
-                <li>identificare gli Utenti che utilizzano il Portale in qualità di Delegati degli
-                    Enti;</li>
-                <li>permettere agli amministratori di sistema di svolgere tutte le funzioni di
-                    amministrazione, compresa la gestione dei permessi degli Utenti per motivi di
-                    sicurezza.</li>
-        </ul>
-        <p>
-        I dati relativi agli identificatori online e alla navigazione sono raccolti altresì per
-        necessità legate al funzionamento, alla manutenzione e alla sicurezza del Portale.
-        </p>
-        <p>
-        I dati personali dell’Utente possono essere utilizzati dal Titolare in giudizio o nelle
-        fasi propedeutiche alla sua eventuale instaurazione per la difesa da abusi perpetrati
-        dall’Utente.
-        </p>
-        <p>
-        L’Utente è consapevole che il Titolare potrebbe dover comunicare i dati personali trattati,
-        su richiesta delle pubbliche Autorità.
-        </p>
-        <p>
-        Gli Utenti possono ottenere chiarimenti sulla finalità della raccolta dei dati o su quali
-        dati siano effettivamente acquisiti, contattando il Titolare.
-        </p>
-        <br>
-        <p>
-<h3>Categorie di soggetti ai quali i dati personali possono essere comunicati</h3>
-        Il Titolare potrà comunicare, per il perseguimento delle finalità sopra indicate, alcuni
-        dati personali anche a:
-        <ul>
+              volontariamente di iscriversi al Portale per effettuare test (art. 6, comma 1,
+              lett. a) del Regolamento).
+            </li>
+          </ul>
+          <br>
+          <p>
+          <h3>Finalità del trattamento</h3>
+          </p>
+          <p>
+            I dati degli Utenti sono raccolti per le seguenti finalità:
+          </p>
+          <ul>
+            <li>
+              permettere a un Utente di:
+              <ul>
+                <li>effettuare test, contribuire al miglioramento del Portale e della
+                  Piattaforma IO;
+                </li>
+                <li>modificare i dati dei Servizi;</li>
+                <li>ottenere le chiavi di autenticazione (API Key) per ogni Servizio al fine di
+                  attivare i Servizi dell’Ente;
+                </li>
+                <li>gestire la composizione dei Messaggi e delle schede servizio per ciascun
+                  Servizio dell'Ente attivato dagli Utenti;
+                </li>
+                <li>utilizzare ogni altra funzionalità prevista e disponibile per gli Utenti
+                  nel Portale.
+                </li>
+              </ul>
+            <li>identificare gli Utenti che utilizzano il Portale in qualità di Delegati degli
+              Enti;
+            </li>
+            <li>permettere agli amministratori di sistema di svolgere tutte le funzioni di
+              amministrazione, compresa la gestione dei permessi degli Utenti per motivi di
+              sicurezza.
+            </li>
+          </ul>
+          <p>
+            I dati relativi agli identificatori online e alla navigazione sono raccolti altresì per
+            necessità legate al funzionamento, alla manutenzione e alla sicurezza del Portale.
+          </p>
+          <p>
+            I dati personali dell’Utente possono essere utilizzati dal Titolare in giudizio o nelle
+            fasi propedeutiche alla sua eventuale instaurazione per la difesa da abusi perpetrati
+            dall’Utente.
+          </p>
+          <p>
+            L’Utente è consapevole che il Titolare potrebbe dover comunicare i dati personali trattati,
+            su richiesta delle pubbliche Autorità.
+          </p>
+          <p>
+            Gli Utenti possono ottenere chiarimenti sulla finalità della raccolta dei dati o su quali
+            dati siano effettivamente acquisiti, contattando il Titolare.
+          </p>
+          <br>
+          <p>
+          <h3>Categorie di soggetti ai quali i dati personali possono essere comunicati</h3>
+          Il Titolare potrà comunicare, per il perseguimento delle finalità sopra indicate, alcuni
+          dati personali anche a:
+          <ul>
             <li>soggetti terzi che forniscono un servizio al Titolare stesso e che tratteranno i
-                dati personali in qualità di responsabili del trattamento;</li>
+              dati personali in qualità di responsabili del trattamento;
+            </li>
             <li>altri soggetti terzi, pubblici o privati, che ne facciano richiesta alla PagoPA SpA
-                per l’esecuzione di un compito di interesse pubblico o connesso all’esercizio di un
-                pubblico potere o per adempiere a un obbligo legale.</li>
-        </ul>
-        I destinatari sono nominati, ove richiesto dalla normativa, Responsabili del trattamento da
-        parte del Titolare. L’elenco dei responsabili del trattamento può essere richiesto al
-        Titolare in qualsiasi momento, scrivendo a <a href:"mailtodpo@pagopa.it">dpo@pagopa.it</a>
-        </p>
-        <br>
-        <p>
-<h3>Trasferimento dati fuori dall’UE</h3>
-        Alcuni dei fornitori terzi che utilizziamo risiedono negli USA. Abbiamo concluso con tali
-        fornitori accordi di servizio ai sensi dell’art. 28 del Regolamento. Tutti i fornitori sono
-        conformi al Regolamento e, in assenza di altre misure di garanzia previste dal Regolamento,
-        abbiamo concluso con loro le Clausole Contrattuali della Commissione Europea per garantire
-        adeguati livelli di tutela. Una copia delle garanzie poste in essere può essere richiesta
-        in qualsiasi momento, scrivendo a <a href:"dpo@pagopa.it">dpo@pagopa.it</a>
-        </p>
-        <br>
-        <p>
-<h3>Tempi di conservazione dei dati</h3>
-        I dati personali raccolti saranno conservati per per il periodo di tempo necessario
-        all’utilizzo del Portale da parte dell’Utente, anche ove contrattualmente determinato.
-        Resta salvo il trattamento fondato su altra base giuridica, ivi inclusa quella di fare
-        fronte a eventuali contestazioni o contenziosi, e in tal caso i dati verranno
-        successivamente trattati conformemente a quanto previsto dagli obblighi di legge. Per
-        maggiori informazioni è possibile scrivere a <a href:"dpo@pagopa.it">dpo@pagopa.it</a>
-        </p>
-        <br>
-        <p>
-<h3>Diritti degli interessati</h3>
-        Gli interessati hanno il diritto di ottenere, nei casi previsti, l’accesso ai propri dati
-        personali e la rettifica o la cancellazione degli stessi o la limitazione del trattamento
-        che li riguarda o di opporsi al trattamento (artt. 15 e ss. del Regolamento). Tali
-        richieste potranno essere indirizzate al Titolare, scrivendo a <a href:"dpo@pagopa.it">dpo@pagopa.it</a>
-        </p>
-        <br>
-        <p>
-<h3>Diritti di reclamo</h3>
-        Gli interessati che ritengono che il trattamento dei dati personali a loro riferiti,
-        effettuato attraverso il Portale avvenga in violazione di quanto previsto dal Regolamento
-        hanno il diritto di proporre reclamo al Garante, come previsto dall’art. 77 del Regolamento
-        stesso, o di adire le opportune sedi giudiziarie (art. 79 del Regolamento).
-        </p>
-
+              per l’esecuzione di un compito di interesse pubblico o connesso all’esercizio di un
+              pubblico potere o per adempiere a un obbligo legale.
+            </li>
+          </ul>
+          I destinatari sono nominati, ove richiesto dalla normativa, Responsabili del trattamento da
+          parte del Titolare. L’elenco dei responsabili del trattamento può essere richiesto al
+          Titolare in qualsiasi momento, scrivendo a <a href:"mailtodpo@pagopa.it">dpo@pagopa.it</a>
+          </p>
+          <br>
+          <p>
+          <h3>Trasferimento dati fuori dall’UE</h3>
+          Alcuni dei fornitori terzi che utilizziamo risiedono negli USA. Abbiamo concluso con tali
+          fornitori accordi di servizio ai sensi dell’art. 28 del Regolamento. Tutti i fornitori sono
+          conformi al Regolamento e, in assenza di altre misure di garanzia previste dal Regolamento,
+          abbiamo concluso con loro le Clausole Contrattuali della Commissione Europea per garantire
+          adeguati livelli di tutela. Una copia delle garanzie poste in essere può essere richiesta
+          in qualsiasi momento, scrivendo a <a href:"dpo@pagopa.it">dpo@pagopa.it</a>
+          </p>
+          <br>
+          <p>
+          <h3>Tempi di conservazione dei dati</h3>
+          I dati personali raccolti saranno conservati per per il periodo di tempo necessario
+          all’utilizzo del Portale da parte dell’Utente, anche ove contrattualmente determinato.
+          Resta salvo il trattamento fondato su altra base giuridica, ivi inclusa quella di fare
+          fronte a eventuali contestazioni o contenziosi, e in tal caso i dati verranno
+          successivamente trattati conformemente a quanto previsto dagli obblighi di legge. Per
+          maggiori informazioni è possibile scrivere a <a href:"dpo@pagopa.it">dpo@pagopa.it</a>
+          </p>
+          <br>
+          <p>
+          <h3>Diritti degli interessati</h3>
+          Gli interessati hanno il diritto di ottenere, nei casi previsti, l’accesso ai propri dati
+          personali e la rettifica o la cancellazione degli stessi o la limitazione del trattamento
+          che li riguarda o di opporsi al trattamento (artt. 15 e ss. del Regolamento). Tali
+          richieste potranno essere indirizzate al Titolare, scrivendo a <a href:"dpo@pagopa.it">dpo@pagopa.it</a>
+          </p>
+          <br>
+          <p>
+          <h3>Diritti di reclamo</h3>
+          Gli interessati che ritengono che il trattamento dei dati personali a loro riferiti,
+          effettuato attraverso il Portale avvenga in violazione di quanto previsto dal Regolamento
+          hanno il diritto di proporre reclamo al Garante, come previsto dall’art. 77 del Regolamento
+          stesso, o di adire le opportune sedi giudiziarie (art. 79 del Regolamento).
+          </p>
+        </div>
       </div>
     </div>
-
-  </div>
-</body>
-
+  </body>
 </html>


### PR DESCRIPTION
### This PR
Replacing old privacy policy provided by AgID with new policy provided by PagoPA as data controller for processing of developers' personal data.

Plus:
- Introduced additional style rules to allow indented unordered list;
- added `shrink-to-fit=no` attribute in viewport metatag to improve viewport's rendering from mobile. 


### Link with master branch
This PR has the same subject of #111 on `master` but includes some improvements. Since the site is served by both branches, after merging, `master` should be re-aligned with this version, otherwise applicable css rules fail to load.

Changes with respect to #111 includes:
- code formatting;
- removed commented code;
- re-inserted `X-UA-Compatible` meta tag that was in the original code and aims to improve rendering for older versions of IE (just in case).
