### PR TITLE
[#ENTE-70] User can upload and modify own services logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,4 +137,4 @@ To set up the customization:
 yarn gh-pages
 ```
 
-* Refer to the [installation manual](https://github.com/pagopa/io-developer-portal-backend) to customize the sign-up and sign-in default forms
+* Refer to the [installation manual](https://github.com/pagopa/io-developer-portal-backend) to customize the sign-up and sign-in default forms.

--- a/src/__integrations__/upload_logo_services.test.ts
+++ b/src/__integrations__/upload_logo_services.test.ts
@@ -11,6 +11,7 @@ import { none, option } from "fp-ts/lib/Option";
 import SerializableSet from "json-set-map/build/src/set";
 import { IExtendedUserContract } from "../apim_operations";
 
+import { SubscriptionContract } from "azure-arm-apimanagement/lib/models";
 import { ServiceId } from "../../generated/api/ServiceId";
 
 afterEach(() => {
@@ -50,11 +51,24 @@ const logo = { logo: "logo_base_64" } as Logo;
 
 const apiManagementClientMock = ({} as unknown) as ApiManagementClient;
 
+const subscriptionContract: SubscriptionContract & { readonly name: string } = {
+  name: "name",
+  primaryKey: "234324",
+  productId: "1234",
+  secondaryKey: "343434",
+  state: "state",
+  userId: "1234"
+};
+
 describe("putServiceLogo", () => {
   it("should respond with IResponseSuccessRedirectToResource if logo upload was successfull", async () => {
     jest
       .spyOn(apim, "getApimUser")
       .mockReturnValueOnce(Promise.resolve(option.of(adminUserContract)));
+
+    jest
+      .spyOn(apim, "getUserSubscription")
+      .mockReturnValueOnce(Promise.resolve(option.of(subscriptionContract)));
 
     jest
       .spyOn(services.notificationApiClient, "uploadServiceLogo")
@@ -88,10 +102,14 @@ describe("putServiceLogo", () => {
     expect(result.kind).toBe("IResponseErrorNotFound");
   });
 
-  it("should respond with ResponseErrorForbiddenNotAuthorized if user is not admin", async () => {
+  it("should respond with ResponseErrorForbiddenNotAuthorized if user is not the service owner", async () => {
     jest
       .spyOn(apim, "getApimUser")
       .mockReturnValueOnce(Promise.resolve(option.of(userContract)));
+
+    jest
+      .spyOn(apim, "getUserSubscription")
+      .mockReturnValueOnce(Promise.resolve(none));
 
     const result = await putServiceLogo(
       apiManagementClientMock,
@@ -100,6 +118,24 @@ describe("putServiceLogo", () => {
       logo
     );
     expect(result.kind).toBe("IResponseErrorForbiddenNotAuthorized");
+  });
+
+  it("should respond with IResponseInternal if getUserSubscription fail", async () => {
+    jest
+      .spyOn(apim, "getApimUser")
+      .mockReturnValueOnce(Promise.resolve(option.of(adminUserContract)));
+
+    jest
+      .spyOn(apim, "getUserSubscription")
+      .mockReturnValueOnce(Promise.reject(new Error("Api Error")));
+
+    const result = await putServiceLogo(
+      apiManagementClientMock,
+      adUser,
+      serviceId,
+      logo
+    );
+    expect(result.kind).toBe("IResponseErrorInternal");
   });
 });
 

--- a/src/__integrations__/upload_logo_services.test.ts
+++ b/src/__integrations__/upload_logo_services.test.ts
@@ -120,7 +120,7 @@ describe("putServiceLogo", () => {
     expect(result.kind).toBe("IResponseErrorForbiddenNotAuthorized");
   });
 
-  it("should respond with IResponseInternal if getUserSubscription fail", async () => {
+  it("should respond with IResponseErrorInternal if getUserSubscription fail", async () => {
     jest
       .spyOn(apim, "getApimUser")
       .mockReturnValueOnce(Promise.resolve(option.of(adminUserContract)));

--- a/src/controllers/__tests__/services.test.ts
+++ b/src/controllers/__tests__/services.test.ts
@@ -13,6 +13,7 @@ import { Logo } from "../../../generated/api/Logo";
 import { AdUser } from "../../bearer_strategy";
 import { putOrganizationLogo, putServiceLogo } from "../services";
 
+import { SubscriptionContract } from "azure-arm-apimanagement/lib/models";
 import SerializableSet from "json-set-map/build/src/set";
 import { ServiceId } from "../../../generated/api/ServiceId";
 import { IExtendedUserContract } from "../../apim_operations";
@@ -33,13 +34,22 @@ const userContract: IExtendedUserContract = {
   name: "name"
 };
 
+const subscriptionContract: SubscriptionContract & { readonly name: string } = {
+  name: "name",
+  primaryKey: "234324",
+  productId: "1234",
+  secondaryKey: "343434",
+  state: "state",
+  userId: "1234"
+};
+
 const responseSuccess = ResponseSuccessRedirectToResource(
   {},
   "services/serviceId.png",
   {}
 );
 
-const responseErrorNotFoaund = ResponseErrorNotFound(
+const responseErrorNotFound = ResponseErrorNotFound(
   "API user not found",
   "Cannot find a user in the API management with the provided email address"
 );
@@ -65,8 +75,8 @@ describe("putServiceLogo", () => {
       .mockReturnValueOnce(taskEither.of(userContract));
 
     jest
-      .spyOn(uploadTasks, "checkAdminTask")
-      .mockReturnValueOnce(taskEither.of(userContract));
+      .spyOn(uploadTasks, "getUserSubscriptionTask")
+      .mockReturnValueOnce(taskEither.of(subscriptionContract));
 
     jest
       .spyOn(uploadTasks, "uploadServiceLogoTask")
@@ -84,7 +94,7 @@ describe("putServiceLogo", () => {
   it("should respond with IResponseErrorNotFound if cannot find a user in the API management", async () => {
     jest
       .spyOn(uploadTasks, "getApimUserTask")
-      .mockReturnValueOnce(fromLeft(responseErrorNotFoaund));
+      .mockReturnValueOnce(fromLeft(responseErrorNotFound));
 
     const result = await putServiceLogo(
       apiManagementClientMock,
@@ -95,13 +105,13 @@ describe("putServiceLogo", () => {
     expect(result.kind).toBe("IResponseErrorNotFound");
   });
 
-  it("should respond with ResponseErrorForbiddenNotAuthorized if user is not admin", async () => {
+  it("should respond with ResponseErrorForbiddenNotAuthorized if user is not admin and is not the service owner", async () => {
     jest
       .spyOn(uploadTasks, "getApimUserTask")
       .mockReturnValueOnce(taskEither.of(userContract));
 
     jest
-      .spyOn(uploadTasks, "checkAdminTask")
+      .spyOn(uploadTasks, "getUserSubscriptionTask")
       .mockReturnValueOnce(fromLeft(ResponseErrorForbiddenNotAuthorized));
 
     const result = await putServiceLogo(
@@ -140,7 +150,7 @@ describe("putOrganizationLogo", () => {
   it("should respond with IResponseErrorNotFound if cannot find a user in the API management", async () => {
     jest
       .spyOn(uploadTasks, "getApimUserTask")
-      .mockReturnValueOnce(fromLeft(responseErrorNotFoaund));
+      .mockReturnValueOnce(fromLeft(responseErrorNotFound));
 
     const result = await putOrganizationLogo(
       apiManagementClientMock,

--- a/src/controllers/services.ts
+++ b/src/controllers/services.ts
@@ -45,6 +45,7 @@ import { CIDR } from "../../generated/api/CIDR";
 import {
   checkAdminTask,
   getApimUserTask,
+  getUserSubscriptionTask,
   uploadOrganizationLogoTask,
   uploadServiceLogoTask
 } from "../middlewares/upload_logo";
@@ -213,7 +214,7 @@ export async function putServiceLogo(
   serviceLogo: ApiLogo
 ): Promise<IResponseSuccessRedirectToResource<{}, {}> | ErrorResponses> {
   return getApimUserTask(apiClient, authenticatedUser)
-    .chain(user => checkAdminTask(user))
+    .chain(user => getUserSubscriptionTask(apiClient, serviceId, user))
     .chain(() => uploadServiceLogoTask(serviceId, serviceLogo))
     .fold<IResponseSuccessRedirectToResource<{}, {}> | ErrorResponses>(
       identity,

--- a/src/middlewares/upload_logo.ts
+++ b/src/middlewares/upload_logo.ts
@@ -43,7 +43,7 @@ export const getApimUserTask = (
   apiClient: ApiManagementClient,
   authenticatedUser: AdUser
 ): TaskEither<ErrorResponses, IExtendedUserContract> =>
-  tryCatch<ErrorResponses, Option<IExtendedUserContract>>(
+  tryCatch(
     () => getApimUser(apiClient, authenticatedUser.emails[0]),
     errors => ResponseErrorInternal(toError(errors).message)
   ).foldTaskEither<ErrorResponses, IExtendedUserContract>(
@@ -148,16 +148,15 @@ export const getUserSubscriptionTask = (
           : authenticatedApimUser.id
       ),
     errors => ResponseErrorInternal(toError(errors).message)
-  ).chain<SubscriptionContract & { readonly name: string }>(
-    maybeResponse =>
-      maybeResponse.foldL<
-        TaskEither<
-          ErrorResponses,
-          SubscriptionContract & { readonly name: string }
-        >
-      >(
-        () => fromLeft(ResponseErrorForbiddenNotAuthorized),
-        _ => taskEither.of(_)
-      ) // folL,
+  ).chain<SubscriptionContract & { readonly name: string }>(maybeResponse =>
+    maybeResponse.foldL<
+      TaskEither<
+        ErrorResponses,
+        SubscriptionContract & { readonly name: string }
+      >
+    >(
+      () => fromLeft(ResponseErrorForbiddenNotAuthorized),
+      _ => taskEither.of(_)
+    )
   );
 };

--- a/src/middlewares/upload_logo.ts
+++ b/src/middlewares/upload_logo.ts
@@ -12,6 +12,7 @@ import {
 import { OrganizationFiscalCode } from "italia-ts-commons/lib/strings";
 import {
   getApimUser,
+  getUserSubscription,
   IExtendedUserContract,
   isAdminUser
 } from "../apim_operations";
@@ -29,16 +30,20 @@ import {
   tryCatch
 } from "fp-ts/lib/TaskEither";
 
+import { Option } from "fp-ts/lib/Option";
+
 import { ErrorResponses, notificationApiClient } from "../controllers/services";
 
+import { SubscriptionContract } from "azure-arm-apimanagement/lib/models";
 import { fromNullable, toError } from "fp-ts/lib/Either";
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import { ServiceId } from "../../generated/api/ServiceId";
 
 export const getApimUserTask = (
   apiClient: ApiManagementClient,
   authenticatedUser: AdUser
 ): TaskEither<ErrorResponses, IExtendedUserContract> =>
-  tryCatch(
+  tryCatch<ErrorResponses, Option<IExtendedUserContract>>(
     () => getApimUser(apiClient, authenticatedUser.emails[0]),
     errors => ResponseErrorInternal(toError(errors).message)
   ).foldTaskEither<ErrorResponses, IExtendedUserContract>(
@@ -121,3 +126,38 @@ export const uploadOrganizationLogoTask = (
             )
           : fromLeft(ResponseErrorInternal(toError(errorOrResponse).message))
     );
+
+export const getUserSubscriptionTask = (
+  apiClient: ApiManagementClient,
+  serviceId: NonEmptyString,
+  authenticatedApimUser: IExtendedUserContract
+): TaskEither<
+  ErrorResponses,
+  SubscriptionContract & { readonly name: string }
+> => {
+  return tryCatch<
+    ErrorResponses,
+    Option<SubscriptionContract & { readonly name: string }>
+  >(
+    () =>
+      getUserSubscription(
+        apiClient,
+        serviceId,
+        isAdminUser(authenticatedApimUser)
+          ? undefined
+          : authenticatedApimUser.id
+      ),
+    errors => ResponseErrorInternal(toError(errors).message)
+  ).chain<SubscriptionContract & { readonly name: string }>(
+    maybeResponse =>
+      maybeResponse.foldL<
+        TaskEither<
+          ErrorResponses,
+          SubscriptionContract & { readonly name: string }
+        >
+      >(
+        () => fromLeft(ResponseErrorForbiddenNotAuthorized),
+        _ => taskEither.of(_)
+      ) // folL,
+  );
+};


### PR DESCRIPTION
#### List of Changes
- User can upload and modify own services logo

#### Motivation and Context
A limited user should update `serviceLogo` to reduce the workload for Admins to fix wrong or missing information.

#### How Has This Been Tested?
- unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)