### PR TITLE
[#ENTE-118] Fix metadata fields delete

### DIFF
--- a/src/utils/__tests__/conversions.test.ts
+++ b/src/utils/__tests__/conversions.test.ts
@@ -1,5 +1,4 @@
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
-import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
+import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import SerializableSet from "json-set-map/build/src/set";
 import { CIDR } from "../../../generated/api/CIDR";
 import { OrganizationFiscalCode } from "../../../generated/api/OrganizationFiscalCode";
@@ -119,7 +118,7 @@ describe("getServicePayloadUpdater", () => {
         token_name: "NEW_TOKEN" as NonEmptyString
       }
     });
-    expect(payload.service_metadata).toHaveProperty("token_name", undefined);
+    expect(payload.service_metadata).not.toHaveProperty("token_name");
   });
 
   it("should can update token_name if the user is an Admin", () => {
@@ -147,5 +146,27 @@ describe("getServicePayloadUpdater", () => {
       "token_name",
       expectedTokenName
     );
+  });
+
+  it("should can delete a metadata field", () => {
+    const payload = getServicePayloadUpdater({
+      ...userContract,
+      groupNames: new SerializableSet(["apiadmin"])
+    })(
+      {
+        ...aService,
+        service_metadata: {
+          email: "email@example.it" as NonEmptyString, // The metadata field we want to delete
+          scope: ServiceScopeEnum.NATIONAL
+        }
+      },
+      {
+        ...aServicePayload,
+        service_metadata: {
+          scope: ServiceScopeEnum.NATIONAL
+        }
+      }
+    );
+    expect(payload.service_metadata).not.toHaveProperty("email");
   });
 });

--- a/src/utils/conversions.ts
+++ b/src/utils/conversions.ts
@@ -1,3 +1,4 @@
+import { withoutUndefinedValues } from "@pagopa/ts-commons/lib/types";
 import { fromNullable, some } from "fp-ts/lib/Option";
 import { pick } from "italia-ts-commons/lib/types";
 import { Service } from "../../generated/api/Service";
@@ -25,7 +26,6 @@ export const getServicePayloadUpdater = (user: IExtendedUserContract) => (
     : payload;
 
   const serviceMetadata: ServiceMetadata = {
-    ...originalService.service_metadata,
     ...payload.service_metadata,
     // Scope for visible services cannot be changed
     scope:
@@ -43,6 +43,6 @@ export const getServicePayloadUpdater = (user: IExtendedUserContract) => (
   return {
     ...originalService,
     ...filteredPayload,
-    service_metadata: serviceMetadata
+    service_metadata: withoutUndefinedValues(serviceMetadata)
   };
 };


### PR DESCRIPTION
Fix a bug introduced with #121.
Now a metadata field can be deleted.
Add a new unit test covering this scenario.