### PR TITLE
[#IC-116] Abstract session handling

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -180,9 +180,7 @@ definitions:
   #  which abstracts and encompasses any kind of authenticated user's shape
   # So far we have only one inmplementation, AdUser, thus the seems-to-be-useless alias definition
   SessionUser:
-    type: object
-    schema:
-      $ref: '#/definitions/AdUser'  
+    $ref: '#/definitions/AdUser'  
 
   AdUser:
     type: object

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -100,7 +100,7 @@ definitions:
       apimUser:
         $ref: "#/definitions/ExtendedUserContract"
       authenticatedUser:
-        $ref: "#/definitions/AdUser"
+        $ref: "#/definitions/SessionUser"
     required:
       - authenticatedUser
 
@@ -175,6 +175,14 @@ definitions:
         type: string
     required:
       - displayName
+
+  # FIXME: this is a temporary solution to introduce a definition, SessionUser
+  #  which abstracts and encompasses any kind of authenticated user's shape
+  # So far we have only one inmplementation, AdUser, thus the seems-to-be-useless alias definition
+  SessionUser:
+    type: object
+    schema:
+      $ref: '#/definitions/AdUser'  
 
   AdUser:
     type: object

--- a/src/__integrations__/upload_logo_services.test.ts
+++ b/src/__integrations__/upload_logo_services.test.ts
@@ -4,7 +4,7 @@ import * as services from "../controllers/services";
 import ApiManagementClient from "azure-arm-apimanagement";
 import { OrganizationFiscalCode } from "italia-ts-commons/lib/strings";
 import { Logo } from "../../generated/api/Logo";
-import { AdUser } from "../auth-strategies/bearer_strategy";
+import { SessionUser } from "../utils/session";
 import { putOrganizationLogo, putServiceLogo } from "../controllers/services";
 
 import { none, option } from "fp-ts/lib/Option";
@@ -38,6 +38,7 @@ const adminUserContract: apim.IExtendedUserContract = {
 };
 
 const adUser = {
+  kind: "azure-ad" as const,
   emails: ["test@test.it"],
   extension_Department: "deparment",
   extension_Organization: "organization",
@@ -45,7 +46,7 @@ const adUser = {
   family_name: "name",
   given_name: "given_name",
   oid: "oid"
-} as AdUser;
+} as SessionUser;
 
 const logo = { logo: "logo_base_64" } as Logo;
 

--- a/src/__integrations__/upload_logo_services.test.ts
+++ b/src/__integrations__/upload_logo_services.test.ts
@@ -4,8 +4,8 @@ import * as services from "../controllers/services";
 import ApiManagementClient from "azure-arm-apimanagement";
 import { OrganizationFiscalCode } from "italia-ts-commons/lib/strings";
 import { Logo } from "../../generated/api/Logo";
-import { SessionUser } from "../utils/session";
 import { putOrganizationLogo, putServiceLogo } from "../controllers/services";
+import { SessionUser } from "../utils/session";
 
 import { none, option } from "fp-ts/lib/Option";
 import SerializableSet from "json-set-map/build/src/set";
@@ -38,13 +38,13 @@ const adminUserContract: apim.IExtendedUserContract = {
 };
 
 const adUser = {
-  kind: "azure-ad" as const,
   emails: ["test@test.it"],
   extension_Department: "deparment",
   extension_Organization: "organization",
   extension_Service: "service",
   family_name: "name",
   given_name: "given_name",
+  kind: "azure-ad" as const,
   oid: "oid"
 } as SessionUser;
 

--- a/src/__integrations__/upload_logo_services.test.ts
+++ b/src/__integrations__/upload_logo_services.test.ts
@@ -4,7 +4,7 @@ import * as services from "../controllers/services";
 import ApiManagementClient from "azure-arm-apimanagement";
 import { OrganizationFiscalCode } from "italia-ts-commons/lib/strings";
 import { Logo } from "../../generated/api/Logo";
-import { AdUser } from "../bearer_strategy";
+import { AdUser } from "../auth-strategies/bearer_strategy";
 import { putOrganizationLogo, putServiceLogo } from "../controllers/services";
 
 import { none, option } from "fp-ts/lib/Option";

--- a/src/__integrations__/upload_logo_services.test.ts
+++ b/src/__integrations__/upload_logo_services.test.ts
@@ -44,7 +44,6 @@ const adUser = {
   extension_Service: "service",
   family_name: "name",
   given_name: "given_name",
-  kind: "azure-ad" as const,
   oid: "oid"
 } as SessionUser;
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -36,7 +36,7 @@ import {
   OrganizationFiscalCode
 } from "italia-ts-commons/lib/strings";
 
-import { setupBearerStrategy } from "./auth-strategies/bearer_strategy";
+import { setupAzureAdStrategy } from "./auth-strategies/azure_ad_strategy";
 import { initCacheStats } from "./cache";
 import { getConfiguration } from "./controllers/configuration";
 import {
@@ -83,7 +83,7 @@ const JIRA_CONFIG = config.getJiraConfigOrThrow();
 /**
  * Setup an authentication strategy (oauth) for express endpoints.
  */
-setupBearerStrategy(passport, config.creds, async (userId, profile) => {
+setupAzureAdStrategy(passport, config.creds, async (userId, profile) => {
   // executed when the user is logged in
   // userId === profile.oid
   // req.user === profile

--- a/src/app.ts
+++ b/src/app.ts
@@ -83,7 +83,7 @@ const JIRA_CONFIG = config.getJiraConfigOrThrow();
 /**
  * Setup an authentication strategy (oauth) for express endpoints.
  */
-setupAzureAdStrategy(passport, config.creds, async (userId, profile) => {
+setupAzureAdStrategy(passport, config.azureAdCreds, async (userId, profile) => {
   // executed when the user is logged in
   // userId === profile.oid
   // req.user === profile
@@ -103,7 +103,7 @@ app.use(morgan("combined"));
 // Avoid stateful in-memory sessions
 app.use(
   cookieSession({
-    keys: [config.creds.cookieEncryptionKeys[0].key!],
+    keys: [config.azureAdCreds.cookieEncryptionKeys[0].key!],
     name: "session"
   })
 );

--- a/src/app.ts
+++ b/src/app.ts
@@ -36,7 +36,7 @@ import {
   OrganizationFiscalCode
 } from "italia-ts-commons/lib/strings";
 
-import { setupBearerStrategy } from "./bearer_strategy";
+import { setupBearerStrategy } from "./auth-strategies/bearer_strategy";
 import { initCacheStats } from "./cache";
 import { getConfiguration } from "./controllers/configuration";
 import {

--- a/src/auth-strategies/azure_ad_strategy.ts
+++ b/src/auth-strategies/azure_ad_strategy.ts
@@ -61,7 +61,7 @@ export const setupAzureAdStrategy = (
         profile: AdUser,
         done: (
           err: Error | undefined,
-          user?: AdUser & { kind: "azure-ad" }
+          user?: AdUser & { readonly kind: "azure-ad" }
         ) => void
       ) => {
         const user = {

--- a/src/auth-strategies/azure_ad_strategy.ts
+++ b/src/auth-strategies/azure_ad_strategy.ts
@@ -59,12 +59,19 @@ export const setupAzureAdStrategy = (
       (
         _: express.Request,
         profile: AdUser,
-        done: (err: Error | undefined, profile?: AdUser) => void
+        done: (
+          err: Error | undefined,
+          user?: AdUser & { kind: "azure-ad" }
+        ) => void
       ) => {
-        return cb(profile.oid, profile)
+        const user = {
+          ...profile,
+          kind: "azure-ad" as const /* to define which strategy the user is extracted by */
+        };
+        return cb(user.oid, user)
           .then(() => {
-            logger.debug("user authenticated %s", JSON.stringify(profile));
-            return done(undefined, profile);
+            logger.debug("user authenticated %s", JSON.stringify(user));
+            return done(undefined, user);
           })
           .catch(e => {
             logger.error("error during authentication %s", JSON.stringify(e));

--- a/src/auth-strategies/azure_ad_strategy.ts
+++ b/src/auth-strategies/azure_ad_strategy.ts
@@ -1,5 +1,5 @@
 /*
- *  OpenID Connect strategy for passport / express.
+ *  OpenID Connect strategy for passport / express that resolves auth using Azure Active Directory
  */
 import * as express from "express";
 import * as t from "io-ts";
@@ -46,7 +46,7 @@ export type AdUser = t.TypeOf<typeof AdUser>;
 /**
  * Calls a callback on the logged in user's profile.
  */
-export const setupBearerStrategy = (
+export const setupAzureAdStrategy = (
   passportInstance: typeof passport,
   // tslint:disable-next-line:no-any
   creds: any,

--- a/src/auth-strategies/azure_ad_strategy.ts
+++ b/src/auth-strategies/azure_ad_strategy.ts
@@ -59,19 +59,12 @@ export const setupAzureAdStrategy = (
       (
         _: express.Request,
         profile: AdUser,
-        done: (
-          err: Error | undefined,
-          user?: AdUser & { readonly kind: "azure-ad" }
-        ) => void
+        done: (err: Error | undefined, user?: AdUser) => void
       ) => {
-        const user = {
-          ...profile,
-          kind: "azure-ad" as const /* to define which strategy the user is extracted by */
-        };
-        return cb(user.oid, user)
+        return cb(profile.oid, profile)
           .then(() => {
-            logger.debug("user authenticated %s", JSON.stringify(user));
-            return done(undefined, user);
+            logger.debug("user authenticated %s", JSON.stringify(profile));
+            return done(undefined, profile);
           })
           .catch(e => {
             logger.error("error during authentication %s", JSON.stringify(e));

--- a/src/auth-strategies/bearer_strategy.ts
+++ b/src/auth-strategies/bearer_strategy.ts
@@ -4,7 +4,7 @@
 import * as express from "express";
 import * as t from "io-ts";
 import * as passport from "passport";
-import { logger } from "./logger";
+import { logger } from "../logger";
 
 import { EmailString, NonEmptyString } from "italia-ts-commons/lib/strings";
 import { BearerStrategy } from "passport-azure-ad";

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ import { EmailAddress } from "../generated/api/EmailAddress";
 /**
  * Globals and OAuth configuration for the Active Directory B2C tenant / application.
  */
-export const creds = {
+export const azureAdCreds = {
   // Required. It must be tenant-specific endpoint, common endpoint
   // is not supported to use B2C feature.
   identityMetadata: `https://${process.env.TENANT_NAME}.b2clogin.com/${process.env.TENANT_NAME}.onmicrosoft.com/v2.0/.well-known/openid-configuration`,

--- a/src/controllers/__tests__/services.test.ts
+++ b/src/controllers/__tests__/services.test.ts
@@ -15,7 +15,7 @@ import {
   OrganizationFiscalCode
 } from "italia-ts-commons/lib/strings";
 import { Logo } from "../../../generated/api/Logo";
-import { AdUser } from "../../auth-strategies/azure_ad_strategy";
+
 import {
   getReviewStatus,
   newReviewRequest,
@@ -30,6 +30,7 @@ import SerializableSet from "json-set-map/build/src/set";
 import { ServiceId } from "../../../generated/api/ServiceId";
 import { IExtendedUserContract } from "../../apim_operations";
 import { IJiraAPIClient } from "../../jira_client";
+import { SessionUser } from "../../utils/session";
 
 afterEach(() => {
   jest.clearAllMocks();
@@ -67,6 +68,7 @@ const responseErrorNotFound = ResponseErrorNotFound(
 );
 
 const adUser = {
+  kind: "azure-ad" as const,
   emails: ["test@test.it"],
   extension_Department: "deparment",
   extension_Organization: "organization",
@@ -74,7 +76,7 @@ const adUser = {
   family_name: "name",
   given_name: "given_name",
   oid: "oid"
-} as AdUser;
+} as SessionUser;
 
 const logo = { logo: "logo_base_64" } as Logo;
 

--- a/src/controllers/__tests__/services.test.ts
+++ b/src/controllers/__tests__/services.test.ts
@@ -15,7 +15,7 @@ import {
   OrganizationFiscalCode
 } from "italia-ts-commons/lib/strings";
 import { Logo } from "../../../generated/api/Logo";
-import { AdUser } from "../../auth-strategies/bearer_strategy";
+import { AdUser } from "../../auth-strategies/azure_ad_strategy";
 import {
   getReviewStatus,
   newReviewRequest,

--- a/src/controllers/__tests__/services.test.ts
+++ b/src/controllers/__tests__/services.test.ts
@@ -74,7 +74,6 @@ const adUser = {
   extension_Service: "service",
   family_name: "name",
   given_name: "given_name",
-  kind: "azure-ad" as const,
   oid: "oid"
 } as SessionUser;
 

--- a/src/controllers/__tests__/services.test.ts
+++ b/src/controllers/__tests__/services.test.ts
@@ -68,13 +68,13 @@ const responseErrorNotFound = ResponseErrorNotFound(
 );
 
 const adUser = {
-  kind: "azure-ad" as const,
   emails: ["test@test.it"],
   extension_Department: "deparment",
   extension_Organization: "organization",
   extension_Service: "service",
   family_name: "name",
   given_name: "given_name",
+  kind: "azure-ad" as const,
   oid: "oid"
 } as SessionUser;
 

--- a/src/controllers/__tests__/services.test.ts
+++ b/src/controllers/__tests__/services.test.ts
@@ -15,7 +15,7 @@ import {
   OrganizationFiscalCode
 } from "italia-ts-commons/lib/strings";
 import { Logo } from "../../../generated/api/Logo";
-import { AdUser } from "../../bearer_strategy";
+import { AdUser } from "../../auth-strategies/bearer_strategy";
 import {
   getReviewStatus,
   newReviewRequest,

--- a/src/controllers/configuration.ts
+++ b/src/controllers/configuration.ts
@@ -13,13 +13,13 @@ import * as config from "../config";
  * All public data to share with client
  */
 const msalConfig = {
-  audience: `https://${config.tenantName}.onmicrosoft.com/${config.creds.clientID}`,
+  audience: `https://${config.tenantName}.onmicrosoft.com/${config.azureAdCreds.clientID}`,
   authority: `https://${config.tenantName}.b2clogin.com/${config.tenantName}.onmicrosoft.com/${config.policyName}`,
   b2cScopes: [
     `https://${config.tenantName}.onmicrosoft.com/${config.clientName}/user_impersonation`
   ],
-  changePasswordLink: `https://${config.tenantName}.b2clogin.com/${config.tenantName}/oauth2/v2.0/authorize?p=${config.resetPasswordPolicyName}&client_id=${config.creds.clientID}&nonce=defaultNonce&redirect_uri=${config.creds.redirectUrl}&scope=openid&response_type=id_token&prompt=login`,
-  clientID: config.creds.clientID
+  changePasswordLink: `https://${config.tenantName}.b2clogin.com/${config.tenantName}/oauth2/v2.0/authorize?p=${config.resetPasswordPolicyName}&client_id=${config.azureAdCreds.clientID}&nonce=defaultNonce&redirect_uri=${config.azureAdCreds.redirectUrl}&scope=openid&response_type=id_token&prompt=login`,
+  clientID: config.azureAdCreds.clientID
 };
 
 export async function getConfiguration(

--- a/src/controllers/services.ts
+++ b/src/controllers/services.ts
@@ -26,8 +26,8 @@ import {
   getUserSubscription,
   isAdminUser
 } from "../apim_operations";
-import { getApimAccountEmail, SessionUser } from "../utils/session";
 import * as config from "../config";
+import { getApimAccountEmail, SessionUser } from "../utils/session";
 
 import { withDefault } from "italia-ts-commons/lib/types";
 import { Service } from "../../generated/api/Service";
@@ -46,6 +46,7 @@ import { ServiceName } from "../../generated/api/ServiceName";
 import { identity } from "fp-ts/lib/function";
 import { fromPredicate, taskEither } from "fp-ts/lib/TaskEither";
 import { CIDR } from "../../generated/api/CIDR";
+import { getServicePayloadUpdater } from "../conversions";
 import { IJiraAPIClient, SearchJiraIssueResponse } from "../jira_client";
 import {
   checkAdminTask,
@@ -54,7 +55,6 @@ import {
   uploadOrganizationLogoTask,
   uploadServiceLogoTask
 } from "../middlewares/upload_logo";
-import { getServicePayloadUpdater } from "../conversions";
 
 export const ServicePayload = t.partial({
   authorized_cidrs: t.readonlyArray(CIDR, "array of CIDR"),

--- a/src/controllers/services.ts
+++ b/src/controllers/services.ts
@@ -26,7 +26,7 @@ import {
   getUserSubscription,
   isAdminUser
 } from "../apim_operations";
-import { AdUser } from "../auth-strategies/bearer_strategy";
+import { AdUser } from "../auth-strategies/azure_ad_strategy";
 import * as config from "../config";
 
 import { withDefault } from "italia-ts-commons/lib/types";

--- a/src/controllers/services.ts
+++ b/src/controllers/services.ts
@@ -26,7 +26,7 @@ import {
   getUserSubscription,
   isAdminUser
 } from "../apim_operations";
-import { AdUser } from "../bearer_strategy";
+import { AdUser } from "../auth-strategies/bearer_strategy";
 import * as config from "../config";
 
 import { withDefault } from "italia-ts-commons/lib/types";
@@ -54,7 +54,7 @@ import {
   uploadOrganizationLogoTask,
   uploadServiceLogoTask
 } from "../middlewares/upload_logo";
-import { getServicePayloadUpdater } from "../utils/conversions";
+import { getServicePayloadUpdater } from "../conversions";
 
 export const ServicePayload = t.partial({
   authorized_cidrs: t.readonlyArray(CIDR, "array of CIDR"),

--- a/src/controllers/services.ts
+++ b/src/controllers/services.ts
@@ -26,7 +26,7 @@ import {
   getUserSubscription,
   isAdminUser
 } from "../apim_operations";
-import { SessionUser } from "../utils/session";
+import { getApimAccountEmail, SessionUser } from "../utils/session";
 import * as config from "../config";
 
 import { withDefault } from "italia-ts-commons/lib/types";
@@ -112,7 +112,7 @@ export async function getService(
 > {
   const maybeApimUser = await getApimUser(
     apiClient,
-    authenticatedUser.emails[0]
+    getApimAccountEmail(authenticatedUser)
   );
   if (isNone(maybeApimUser)) {
     return ResponseErrorNotFound(
@@ -168,7 +168,7 @@ export async function putService(
 > {
   const maybeApimUser = await getApimUser(
     apiClient,
-    authenticatedUser.emails[0]
+    getApimAccountEmail(authenticatedUser)
   );
   if (isNone(maybeApimUser)) {
     return ResponseErrorNotFound(
@@ -282,7 +282,7 @@ export async function getReviewStatus(
 > {
   const maybeApimUser = await getApimUser(
     apiClient,
-    authenticatedUser.emails[0]
+    getApimAccountEmail(authenticatedUser)
   );
   if (isNone(maybeApimUser)) {
     return ResponseErrorNotFound(
@@ -360,7 +360,7 @@ export async function newDisableRequest(
 > {
   const maybeApimUser = await getApimUser(
     apiClient,
-    authenticatedUser.emails[0]
+    getApimAccountEmail(authenticatedUser)
   );
   if (isNone(maybeApimUser)) {
     return ResponseErrorNotFound(
@@ -441,7 +441,7 @@ export async function newDisableRequest(
           `Effettua la disattivazione del servizio al link https://developer.io.italia.it/service/${serviceId}` as NonEmptyString,
           {
             delegateName: `${authenticatedUser.given_name} ${authenticatedUser.family_name}` as NonEmptyString,
-            email: authenticatedUser.emails[0],
+            email: getApimAccountEmail(authenticatedUser),
             organizationName: errorOrService.value.organization_name,
             serviceId
           },
@@ -481,7 +481,7 @@ export async function newReviewRequest(
 > {
   const maybeApimUser = await getApimUser(
     apiClient,
-    authenticatedUser.emails[0]
+    getApimAccountEmail(authenticatedUser)
   );
   if (isNone(maybeApimUser)) {
     return ResponseErrorNotFound(
@@ -611,7 +611,8 @@ export async function newReviewRequest(
               `Effettua la review del servizio al link https://developer.io.italia.it/service/${serviceId}` as NonEmptyString,
               {
                 delegateName: `${authenticatedUser.given_name} ${authenticatedUser.family_name}` as NonEmptyString,
-                email: authenticatedUser.emails[0],
+                // QUESTION: use delegate email?
+                email: getApimAccountEmail(authenticatedUser),
                 organizationName: errorOrService.value.organization_name,
                 serviceId
               }

--- a/src/controllers/services.ts
+++ b/src/controllers/services.ts
@@ -26,7 +26,7 @@ import {
   getUserSubscription,
   isAdminUser
 } from "../apim_operations";
-import { AdUser } from "../auth-strategies/azure_ad_strategy";
+import { SessionUser } from "../utils/session";
 import * as config from "../config";
 
 import { withDefault } from "italia-ts-commons/lib/types";
@@ -102,7 +102,7 @@ export type ErrorResponses =
  */
 export async function getService(
   apiClient: ApiManagementClient,
-  authenticatedUser: AdUser,
+  authenticatedUser: SessionUser,
   serviceId: NonEmptyString
 ): Promise<
   | IResponseSuccessJson<Service>
@@ -157,7 +157,7 @@ export async function getService(
  */
 export async function putService(
   apiClient: ApiManagementClient,
-  authenticatedUser: AdUser,
+  authenticatedUser: SessionUser,
   serviceId: NonEmptyString,
   servicePayload: ServicePayload
 ): Promise<
@@ -233,7 +233,7 @@ export async function putService(
  */
 export async function putServiceLogo(
   apiClient: ApiManagementClient,
-  authenticatedUser: AdUser,
+  authenticatedUser: SessionUser,
   serviceId: ServiceId,
   serviceLogo: ApiLogo
 ): Promise<IResponseSuccessRedirectToResource<{}, {}> | ErrorResponses> {
@@ -252,7 +252,7 @@ export async function putServiceLogo(
  */
 export async function putOrganizationLogo(
   apiClient: ApiManagementClient,
-  authenticatedUser: AdUser,
+  authenticatedUser: SessionUser,
   organizationFiscalCode: OrganizationFiscalCode,
   serviceLogo: ApiLogo
 ): Promise<IResponseSuccessRedirectToResource<{}, {}> | ErrorResponses> {
@@ -271,7 +271,7 @@ export async function putOrganizationLogo(
 export async function getReviewStatus(
   apiClient: ApiManagementClient,
   jiraClient: IJiraAPIClient,
-  authenticatedUser: AdUser,
+  authenticatedUser: SessionUser,
   serviceId: NonEmptyString
 ): Promise<
   | IResponseSuccessJson<ReviewStatus>
@@ -348,7 +348,7 @@ export async function getReviewStatus(
 export async function newDisableRequest(
   apiClient: ApiManagementClient,
   jiraClient: IJiraAPIClient,
-  authenticatedUser: AdUser,
+  authenticatedUser: SessionUser,
   serviceId: NonEmptyString,
   jiraConfig: config.IJIRA_CONFIG
 ): Promise<
@@ -469,7 +469,7 @@ export async function newDisableRequest(
 export async function newReviewRequest(
   apiClient: ApiManagementClient,
   jiraClient: IJiraAPIClient,
-  authenticatedUser: AdUser,
+  authenticatedUser: SessionUser,
   serviceId: NonEmptyString,
   jiraConfig: config.IJIRA_CONFIG
 ): Promise<

--- a/src/controllers/subscriptions.ts
+++ b/src/controllers/subscriptions.ts
@@ -24,7 +24,7 @@ import {
   regeneratePrimaryKey,
   regenerateSecondaryKey
 } from "../apim_operations";
-import { SessionUser } from "../utils/session";
+import { getApimAccountEmail, SessionUser } from "../utils/session";
 import { subscribeApimUser, SubscriptionData } from "../new_subscription";
 
 import { fromOption, isLeft } from "fp-ts/lib/Either";
@@ -75,7 +75,7 @@ export async function postSubscriptions(
 > {
   const maybeAuthenticatedApimUser = await getApimUser(
     apiClient,
-    authenticatedUser.emails[0]
+    getApimAccountEmail(authenticatedUser)
   );
 
   const isAuthenticatedAdmin = maybeAuthenticatedApimUser.exists(isAdminUser);
@@ -85,7 +85,9 @@ export async function postSubscriptions(
   // which has the provided 'userMail' in case the logged in user
   // is the administrator.
   const email =
-    isAuthenticatedAdmin && userEmail ? userEmail : authenticatedUser.emails[0];
+    isAuthenticatedAdmin && userEmail
+      ? userEmail
+      : getApimAccountEmail(authenticatedUser);
 
   const errorOrRetrievedApimUser =
     subscriptionData.new_user && subscriptionData.new_user.email === email
@@ -133,7 +135,10 @@ export async function putSubscriptionKey(
   | IResponseErrorInternal
   | IResponseErrorNotFound
 > {
-  const maybeUser = await getApimUser(apiClient, authenticatedUser.emails[0]);
+  const maybeUser = await getApimUser(
+    apiClient,
+    getApimAccountEmail(authenticatedUser)
+  );
   if (isNone(maybeUser)) {
     return ResponseErrorForbiddenNotAuthorized;
   }

--- a/src/controllers/subscriptions.ts
+++ b/src/controllers/subscriptions.ts
@@ -24,7 +24,7 @@ import {
   regeneratePrimaryKey,
   regenerateSecondaryKey
 } from "../apim_operations";
-import { AdUser } from "../auth-strategies/azure_ad_strategy";
+import { SessionUser } from "../utils/session";
 import { subscribeApimUser, SubscriptionData } from "../new_subscription";
 
 import { fromOption, isLeft } from "fp-ts/lib/Either";
@@ -35,7 +35,7 @@ import { getActualUser } from "../middlewares/actual_user";
  */
 export async function getSubscriptions(
   apiClient: ApiManagementClient,
-  authenticatedUser: AdUser,
+  authenticatedUser: SessionUser,
   userEmail?: EmailString
 ): Promise<
   | IResponseSuccessJson<SubscriptionCollection>
@@ -65,7 +65,7 @@ export async function getSubscriptions(
  */
 export async function postSubscriptions(
   apiClient: ApiManagementClient,
-  authenticatedUser: AdUser,
+  authenticatedUser: SessionUser,
   subscriptionData: SubscriptionData,
   userEmail?: EmailString
 ): Promise<
@@ -124,7 +124,7 @@ export async function postSubscriptions(
  */
 export async function putSubscriptionKey(
   apiClient: ApiManagementClient,
-  authenticatedUser: AdUser,
+  authenticatedUser: SessionUser,
   subscriptionId: NonEmptyString,
   keyType: NonEmptyString
 ): Promise<

--- a/src/controllers/subscriptions.ts
+++ b/src/controllers/subscriptions.ts
@@ -24,7 +24,7 @@ import {
   regeneratePrimaryKey,
   regenerateSecondaryKey
 } from "../apim_operations";
-import { AdUser } from "../auth-strategies/bearer_strategy";
+import { AdUser } from "../auth-strategies/azure_ad_strategy";
 import { subscribeApimUser, SubscriptionData } from "../new_subscription";
 
 import { fromOption, isLeft } from "fp-ts/lib/Either";

--- a/src/controllers/subscriptions.ts
+++ b/src/controllers/subscriptions.ts
@@ -24,8 +24,8 @@ import {
   regeneratePrimaryKey,
   regenerateSecondaryKey
 } from "../apim_operations";
-import { getApimAccountEmail, SessionUser } from "../utils/session";
 import { subscribeApimUser, SubscriptionData } from "../new_subscription";
+import { getApimAccountEmail, SessionUser } from "../utils/session";
 
 import { fromOption, isLeft } from "fp-ts/lib/Either";
 import { getActualUser } from "../middlewares/actual_user";

--- a/src/controllers/subscriptions.ts
+++ b/src/controllers/subscriptions.ts
@@ -24,7 +24,7 @@ import {
   regeneratePrimaryKey,
   regenerateSecondaryKey
 } from "../apim_operations";
-import { AdUser } from "../bearer_strategy";
+import { AdUser } from "../auth-strategies/bearer_strategy";
 import { subscribeApimUser, SubscriptionData } from "../new_subscription";
 
 import { fromOption, isLeft } from "fp-ts/lib/Either";

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -19,9 +19,9 @@ import {
   IExtendedUserContract,
   isAdminUser
 } from "../apim_operations";
-import { getApimAccountEmail, SessionUser } from "../utils/session";
 import { logger } from "../logger";
 import { getActualUser } from "../middlewares/actual_user";
+import { getApimAccountEmail, SessionUser } from "../utils/session";
 
 interface IUserData {
   readonly apimUser: IExtendedUserContract | undefined;

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -19,7 +19,7 @@ import {
   IExtendedUserContract,
   isAdminUser
 } from "../apim_operations";
-import { AdUser } from "../auth-strategies/bearer_strategy";
+import { AdUser } from "../auth-strategies/azure_ad_strategy";
 import { logger } from "../logger";
 import { getActualUser } from "../middlewares/actual_user";
 

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -19,18 +19,18 @@ import {
   IExtendedUserContract,
   isAdminUser
 } from "../apim_operations";
-import { AdUser } from "../auth-strategies/azure_ad_strategy";
+import { SessionUser } from "../utils/session";
 import { logger } from "../logger";
 import { getActualUser } from "../middlewares/actual_user";
 
 interface IUserData {
   readonly apimUser: IExtendedUserContract | undefined;
-  readonly authenticatedUser: AdUser;
+  readonly authenticatedUser: SessionUser;
 }
 
 export async function getUser(
   apiClient: ApiManagementClient,
-  authenticatedUser: AdUser,
+  authenticatedUser: SessionUser,
   userEmail?: EmailString
 ): Promise<
   IResponseSuccessJson<IUserData> | IResponseErrorForbiddenNotAuthorized
@@ -56,7 +56,7 @@ type ApimUser = Pick<UserContract, "email" | "firstName" | "lastName">;
  */
 export async function getUsers(
   apiClient: ApiManagementClient,
-  authenticatedUser: AdUser
+  authenticatedUser: SessionUser
 ): Promise<
   | IResponseSuccessJson<{
       readonly items: ReadonlyArray<ApimUser>;

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -19,7 +19,7 @@ import {
   IExtendedUserContract,
   isAdminUser
 } from "../apim_operations";
-import { SessionUser } from "../utils/session";
+import { getApimAccountEmail, SessionUser } from "../utils/session";
 import { logger } from "../logger";
 import { getActualUser } from "../middlewares/actual_user";
 
@@ -68,7 +68,7 @@ export async function getUsers(
 > {
   const maybeApimUser = await getApimUser(
     apiClient,
-    authenticatedUser.emails[0]
+    getApimAccountEmail(authenticatedUser)
   );
   if (isNone(maybeApimUser)) {
     return ResponseErrorNotFound(

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -19,7 +19,7 @@ import {
   IExtendedUserContract,
   isAdminUser
 } from "../apim_operations";
-import { AdUser } from "../bearer_strategy";
+import { AdUser } from "../auth-strategies/bearer_strategy";
 import { logger } from "../logger";
 import { getActualUser } from "../middlewares/actual_user";
 

--- a/src/conversions.ts
+++ b/src/conversions.ts
@@ -1,15 +1,16 @@
 import { withoutUndefinedValues } from "@pagopa/ts-commons/lib/types";
 import { fromNullable, some } from "fp-ts/lib/Option";
 import { pick } from "italia-ts-commons/lib/types";
-import { Service } from "../../generated/api/Service";
-import { ServiceMetadata } from "../../generated/api/ServiceMetadata";
-import { ServiceScopeEnum } from "../../generated/api/ServiceScope";
-import { SpecialServiceMetadata } from "../../generated/api/SpecialServiceMetadata";
-import { StandardServiceCategoryEnum } from "../../generated/api/StandardServiceCategory";
-import { StandardServiceMetadata } from "../../generated/api/StandardServiceMetadata";
-import { VisibleServicePayload } from "../../generated/api/VisibleServicePayload";
-import { IExtendedUserContract, isAdminUser } from "../apim_operations";
-import { ServicePayload } from "../controllers/services";
+
+import { Service } from "../generated/api/Service";
+import { ServiceMetadata } from "../generated/api/ServiceMetadata";
+import { ServiceScopeEnum } from "../generated/api/ServiceScope";
+import { SpecialServiceMetadata } from "../generated/api/SpecialServiceMetadata";
+import { StandardServiceCategoryEnum } from "../generated/api/StandardServiceCategory";
+import { StandardServiceMetadata } from "../generated/api/StandardServiceMetadata";
+import { VisibleServicePayload } from "../generated/api/VisibleServicePayload";
+import { IExtendedUserContract, isAdminUser } from "./apim_operations";
+import { ServicePayload } from "./controllers/services";
 
 export const hasCategory = (
   s?: ServiceMetadata

--- a/src/middlewares/__tests__/upload_logo.test.ts
+++ b/src/middlewares/__tests__/upload_logo.test.ts
@@ -37,13 +37,13 @@ const userContract: apim.IExtendedUserContract = {
 };
 
 const adUser = {
-  kind: "azure-ad" as const,
   emails: ["test@test.it"],
   extension_Department: "deparment",
   extension_Organization: "organization",
   extension_Service: "service",
   family_name: "name",
   given_name: "given_name",
+  kind: "azure-ad" as const,
   oid: "oid"
 } as SessionUser;
 

--- a/src/middlewares/__tests__/upload_logo.test.ts
+++ b/src/middlewares/__tests__/upload_logo.test.ts
@@ -43,7 +43,6 @@ const adUser = {
   extension_Service: "service",
   family_name: "name",
   given_name: "given_name",
-  kind: "azure-ad" as const,
   oid: "oid"
 } as SessionUser;
 

--- a/src/middlewares/__tests__/upload_logo.test.ts
+++ b/src/middlewares/__tests__/upload_logo.test.ts
@@ -4,7 +4,7 @@ import * as services from "../../controllers/services";
 import ApiManagementClient from "azure-arm-apimanagement";
 import { none, option } from "fp-ts/lib/Option";
 import SerializableSet from "json-set-map/build/src/set";
-import { AdUser } from "../../auth-strategies/bearer_strategy";
+import { AdUser } from "../../auth-strategies/azure_ad_strategy";
 import {
   checkAdminTask,
   getApimUserTask,

--- a/src/middlewares/__tests__/upload_logo.test.ts
+++ b/src/middlewares/__tests__/upload_logo.test.ts
@@ -4,7 +4,7 @@ import * as services from "../../controllers/services";
 import ApiManagementClient from "azure-arm-apimanagement";
 import { none, option } from "fp-ts/lib/Option";
 import SerializableSet from "json-set-map/build/src/set";
-import { AdUser } from "../../bearer_strategy";
+import { AdUser } from "../../auth-strategies/bearer_strategy";
 import {
   checkAdminTask,
   getApimUserTask,

--- a/src/middlewares/__tests__/upload_logo.test.ts
+++ b/src/middlewares/__tests__/upload_logo.test.ts
@@ -4,7 +4,6 @@ import * as services from "../../controllers/services";
 import ApiManagementClient from "azure-arm-apimanagement";
 import { none, option } from "fp-ts/lib/Option";
 import SerializableSet from "json-set-map/build/src/set";
-import { AdUser } from "../../auth-strategies/azure_ad_strategy";
 import {
   checkAdminTask,
   getApimUserTask,
@@ -16,6 +15,7 @@ import { Logo } from "../../../generated/api/Logo";
 
 import { OrganizationFiscalCode } from "italia-ts-commons/lib/strings";
 import { ServiceId } from "../../../generated/api/ServiceId";
+import { SessionUser } from "../../utils/session";
 
 afterEach(() => {
   jest.resetAllMocks();
@@ -37,6 +37,7 @@ const userContract: apim.IExtendedUserContract = {
 };
 
 const adUser = {
+  kind: "azure-ad" as const,
   emails: ["test@test.it"],
   extension_Department: "deparment",
   extension_Organization: "organization",
@@ -44,7 +45,7 @@ const adUser = {
   family_name: "name",
   given_name: "given_name",
   oid: "oid"
-} as AdUser;
+} as SessionUser;
 
 const logo = { logo: "logo_base_64" } as Logo;
 

--- a/src/middlewares/actual_user.ts
+++ b/src/middlewares/actual_user.ts
@@ -16,12 +16,12 @@ import {
   IExtendedUserContract,
   isAdminUser
 } from "../apim_operations";
-import { AdUser } from "../auth-strategies/azure_ad_strategy";
 import { logger } from "../logger";
+import { SessionUser } from "../utils/session";
 
 export async function getActualUser(
   apiClient: ApiManagementClient,
-  authenticatedUser: AdUser,
+  authenticatedUser: SessionUser,
   userEmail?: EmailString
 ): Promise<
   Either<IResponseErrorForbiddenNotAuthorized, IExtendedUserContract>

--- a/src/middlewares/actual_user.ts
+++ b/src/middlewares/actual_user.ts
@@ -16,7 +16,7 @@ import {
   IExtendedUserContract,
   isAdminUser
 } from "../apim_operations";
-import { AdUser } from "../bearer_strategy";
+import { AdUser } from "../auth-strategies/bearer_strategy";
 import { logger } from "../logger";
 
 export async function getActualUser(

--- a/src/middlewares/actual_user.ts
+++ b/src/middlewares/actual_user.ts
@@ -16,7 +16,7 @@ import {
   IExtendedUserContract,
   isAdminUser
 } from "../apim_operations";
-import { AdUser } from "../auth-strategies/bearer_strategy";
+import { AdUser } from "../auth-strategies/azure_ad_strategy";
 import { logger } from "../logger";
 
 export async function getActualUser(

--- a/src/middlewares/actual_user.ts
+++ b/src/middlewares/actual_user.ts
@@ -17,7 +17,7 @@ import {
   isAdminUser
 } from "../apim_operations";
 import { logger } from "../logger";
-import { SessionUser } from "../utils/session";
+import { getApimAccountEmail, SessionUser } from "../utils/session";
 
 export async function getActualUser(
   apiClient: ApiManagementClient,
@@ -29,7 +29,7 @@ export async function getActualUser(
   // Get API management groups for the authenticated user
   const maybeApimUser = await getApimUser(
     apiClient,
-    authenticatedUser.emails[0]
+    getApimAccountEmail(authenticatedUser)
   );
 
   // Check if the authenticated user is an administrator

--- a/src/middlewares/upload_logo.ts
+++ b/src/middlewares/upload_logo.ts
@@ -37,14 +37,14 @@ import { SubscriptionContract } from "azure-arm-apimanagement/lib/models";
 import { fromNullable, toError } from "fp-ts/lib/Either";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import { ServiceId } from "../../generated/api/ServiceId";
-import { SessionUser } from "../utils/session";
+import { getApimAccountEmail, SessionUser } from "../utils/session";
 
 export const getApimUserTask = (
   apiClient: ApiManagementClient,
   authenticatedUser: SessionUser
 ): TaskEither<ErrorResponses, IExtendedUserContract> =>
   tryCatch(
-    () => getApimUser(apiClient, authenticatedUser.emails[0]),
+    () => getApimUser(apiClient, getApimAccountEmail(authenticatedUser)),
     errors => ResponseErrorInternal(toError(errors).message)
   ).foldTaskEither<ErrorResponses, IExtendedUserContract>(
     error => fromLeft(error),

--- a/src/middlewares/upload_logo.ts
+++ b/src/middlewares/upload_logo.ts
@@ -16,7 +16,6 @@ import {
   IExtendedUserContract,
   isAdminUser
 } from "../apim_operations";
-import { AdUser } from "../auth-strategies/azure_ad_strategy";
 import * as config from "../config";
 
 import { Logo as ApiLogo } from "../../generated/api/Logo";
@@ -38,10 +37,11 @@ import { SubscriptionContract } from "azure-arm-apimanagement/lib/models";
 import { fromNullable, toError } from "fp-ts/lib/Either";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import { ServiceId } from "../../generated/api/ServiceId";
+import { SessionUser } from "../utils/session";
 
 export const getApimUserTask = (
   apiClient: ApiManagementClient,
-  authenticatedUser: AdUser
+  authenticatedUser: SessionUser
 ): TaskEither<ErrorResponses, IExtendedUserContract> =>
   tryCatch(
     () => getApimUser(apiClient, authenticatedUser.emails[0]),

--- a/src/middlewares/upload_logo.ts
+++ b/src/middlewares/upload_logo.ts
@@ -16,7 +16,7 @@ import {
   IExtendedUserContract,
   isAdminUser
 } from "../apim_operations";
-import { AdUser } from "../bearer_strategy";
+import { AdUser } from "../auth-strategies/bearer_strategy";
 import * as config from "../config";
 
 import { Logo as ApiLogo } from "../../generated/api/Logo";

--- a/src/middlewares/upload_logo.ts
+++ b/src/middlewares/upload_logo.ts
@@ -16,7 +16,7 @@ import {
   IExtendedUserContract,
   isAdminUser
 } from "../apim_operations";
-import { AdUser } from "../auth-strategies/bearer_strategy";
+import { AdUser } from "../auth-strategies/azure_ad_strategy";
 import * as config from "../config";
 
 import { Logo as ApiLogo } from "../../generated/api/Logo";

--- a/src/middlewares/user.ts
+++ b/src/middlewares/user.ts
@@ -4,22 +4,22 @@
  */
 import { IRequestMiddleware } from "italia-ts-commons/lib/request_middleware";
 import { ResponseErrorFromValidationErrors } from "italia-ts-commons/lib/responses";
-import { AdUser } from "../auth-strategies/azure_ad_strategy";
 import { logger } from "../logger";
+import { SessionUser } from "../utils/session";
 
 export function getUserFromRequestMiddleware(): IRequestMiddleware<
   "IResponseErrorValidation",
-  AdUser
+  SessionUser
 > {
   return request =>
     new Promise(resolve => {
-      const validation = AdUser.decode(request.user);
+      const validation = SessionUser.decode(request.user);
       logger.debug(
         "Trying to get authenticated user: %s",
         JSON.stringify(request.user)
       );
       const result = validation.mapLeft(
-        ResponseErrorFromValidationErrors(AdUser)
+        ResponseErrorFromValidationErrors(SessionUser)
       );
       resolve(result);
     });

--- a/src/middlewares/user.ts
+++ b/src/middlewares/user.ts
@@ -4,7 +4,7 @@
  */
 import { IRequestMiddleware } from "italia-ts-commons/lib/request_middleware";
 import { ResponseErrorFromValidationErrors } from "italia-ts-commons/lib/responses";
-import { AdUser } from "../bearer_strategy";
+import { AdUser } from "../auth-strategies/bearer_strategy";
 import { logger } from "../logger";
 
 export function getUserFromRequestMiddleware(): IRequestMiddleware<

--- a/src/middlewares/user.ts
+++ b/src/middlewares/user.ts
@@ -4,7 +4,7 @@
  */
 import { IRequestMiddleware } from "italia-ts-commons/lib/request_middleware";
 import { ResponseErrorFromValidationErrors } from "italia-ts-commons/lib/responses";
-import { AdUser } from "../auth-strategies/bearer_strategy";
+import { AdUser } from "../auth-strategies/azure_ad_strategy";
 import { logger } from "../logger";
 
 export function getUserFromRequestMiddleware(): IRequestMiddleware<

--- a/src/utils/__tests__/conversions.test.ts
+++ b/src/utils/__tests__/conversions.test.ts
@@ -10,7 +10,7 @@ import { StandardServiceCategoryEnum } from "../../../generated/api/StandardServ
 import { StandardServiceMetadata } from "../../../generated/api/StandardServiceMetadata";
 import { IExtendedUserContract } from "../../apim_operations";
 import { ServicePayload } from "../../controllers/services";
-import { getServicePayloadUpdater } from "../conversions";
+import { getServicePayloadUpdater } from "../../conversions";
 
 const userContract: IExtendedUserContract = {
   email: "test@test.it",

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -10,10 +10,7 @@ import { AdUser } from "../auth-strategies/azure_ad_strategy";
  * Abstract shape for user data stored in session
  */
 export type SessionUser = t.TypeOf<typeof SessionUser>;
-export const SessionUser = t.intersection([
-  t.interface({ kind: t.literal("azure-ad") }),
-  AdUser
-]);
+export const SessionUser = AdUser;
 
 /**
  * Lens that extracts the email address for Session user to bind to an APIM account

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,0 +1,15 @@
+/**
+ * Utilities to handle session objects
+ */
+
+import * as t from "io-ts";
+import { AdUser } from "../auth-strategies/azure_ad_strategy";
+
+/**
+ * Abstract shape for user data stored in session
+ */
+export type SessionUser = t.TypeOf<typeof SessionUser>;
+export const SessionUser = t.intersection([
+  t.interface({ kind: t.literal("azure-ad") }),
+  AdUser
+]);

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -3,6 +3,7 @@
  */
 
 import * as t from "io-ts";
+import { EmailAddress } from "../../generated/api/EmailAddress";
 import { AdUser } from "../auth-strategies/azure_ad_strategy";
 
 /**
@@ -13,3 +14,13 @@ export const SessionUser = t.intersection([
   t.interface({ kind: t.literal("azure-ad") }),
   AdUser
 ]);
+
+/**
+ * Lens that extracts the email address for Session user to bind to an APIM account
+ *
+ * @param user
+ * @returns
+ */
+export const getApimAccountEmail = (user: SessionUser): EmailAddress => {
+  return user.emails[0];
+};


### PR DESCRIPTION
This is a refactor that re-arrange session handling, to make it generic and allow for methods other Azure Active Directory to be implemented. No changes in the behavior are meant for this PR. 

Changes:
* actual Passport Strategy implementation has been renamed into Azure AD Strategy
* an abstract `SessionUser` type has been introduced, with the purpose of include different user data shapes coming from different strategies; being `AdUser` the only implementation, those types coincide so far

For a detailed list of changes, please see commit list
