### PR TITLE
[#IC-224] Annotate Organization APIM users

### DIFF
--- a/src/apim_operations.ts
+++ b/src/apim_operations.ts
@@ -438,10 +438,19 @@ export async function getApimUsers(
 
 export async function createApimUserIfNotExists(
   apiClient: ApiManagementClient,
-  userEmail: EmailString,
-  userAdId: string,
-  firstName: string,
-  lastName: string,
+  {
+    userEmail,
+    userAdId,
+    firstName,
+    lastName,
+    note = ""
+  }: {
+    userEmail: EmailString;
+    userAdId: string;
+    firstName: string;
+    lastName: string;
+    note?: string;
+  },
   lconfig: IApimConfig = config
 ): Promise<Option<IExtendedUserContract>> {
   const maybeExistingApimUser = await getApimUser__(
@@ -474,6 +483,7 @@ export async function createApimUserIfNotExists(
           }
         ],
         lastName,
+        note,
         state: "active"
       }
     );

--- a/src/apim_operations.ts
+++ b/src/apim_operations.ts
@@ -445,11 +445,11 @@ export async function createApimUserIfNotExists(
     lastName,
     note = ""
   }: {
-    userEmail: EmailString;
-    userAdId: string;
-    firstName: string;
-    lastName: string;
-    note?: string;
+    readonly userEmail: EmailString;
+    readonly userAdId: string;
+    readonly firstName: string;
+    readonly lastName: string;
+    readonly note?: string;
   },
   lconfig: IApimConfig = config
 ): Promise<Option<IExtendedUserContract>> {

--- a/src/controllers/subscriptions.ts
+++ b/src/controllers/subscriptions.ts
@@ -93,13 +93,12 @@ export async function postSubscriptions(
   const errorOrRetrievedApimUser =
     subscriptionData.new_user && subscriptionData.new_user.email === email
       ? fromOption(ResponseErrorForbiddenNotAuthorized)(
-          await createApimUserIfNotExists(
-            apiClient,
-            subscriptionData.new_user.email,
-            subscriptionData.new_user.adb2c_id,
-            subscriptionData.new_user.first_name,
-            subscriptionData.new_user.last_name
-          )
+          await createApimUserIfNotExists(apiClient, {
+            userEmail: subscriptionData.new_user.email,
+            userAdId: subscriptionData.new_user.adb2c_id,
+            firstName: subscriptionData.new_user.first_name,
+            lastName: subscriptionData.new_user.last_name
+          })
         )
       : await getActualUser(apiClient, authenticatedUser, userEmail);
 

--- a/src/controllers/subscriptions.ts
+++ b/src/controllers/subscriptions.ts
@@ -26,7 +26,11 @@ import {
 } from "../apim_operations";
 
 import { subscribeApimUser, SubscriptionData } from "../new_subscription";
-import { getApimAccountEmail, SessionUser } from "../utils/session";
+import {
+  getApimAccountAnnotation,
+  getApimAccountEmail,
+  SessionUser
+} from "../utils/session";
 
 import { fromOption, isLeft } from "fp-ts/lib/Either";
 import { getActualUser } from "../middlewares/actual_user";
@@ -94,10 +98,11 @@ export async function postSubscriptions(
     subscriptionData.new_user && subscriptionData.new_user.email === email
       ? fromOption(ResponseErrorForbiddenNotAuthorized)(
           await createApimUserIfNotExists(apiClient, {
-            userEmail: subscriptionData.new_user.email,
-            userAdId: subscriptionData.new_user.adb2c_id,
             firstName: subscriptionData.new_user.first_name,
-            lastName: subscriptionData.new_user.last_name
+            lastName: subscriptionData.new_user.last_name,
+            note: getApimAccountAnnotation(authenticatedUser),
+            userAdId: subscriptionData.new_user.adb2c_id,
+            userEmail: subscriptionData.new_user.email
           })
         )
       : await getActualUser(apiClient, authenticatedUser, userEmail);

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -30,3 +30,15 @@ export const getApimAccountEmail = (user: SessionUser): EmailAddress => {
     throw new Error(`Cannot get APIM account email`);
   });
 };
+
+/**
+ * Lens that composes the annotation to be stored on APIM accont, depending on the session user type
+ *
+ * @param user
+ * @returns
+ */
+export const getApimAccountAnnotation = (user: SessionUser): string =>
+  SelfCareUser.is(user)
+    ? // for SelfCare we store Organization's info in notes
+      user.organization.fiscal_code
+    : "";


### PR DESCRIPTION
When creating an APIM account for an Organization, annotate it's foscal_code so it can be easily retrieved.