### PR TITLE
[#IC-256, #IC-280, #IC-275] Proxy all requests to subscription migrations service

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "version": "auto-changelog -p --config .auto-changelog.json --unreleased && git add CHANGELOG.md"
   },
   "dependencies": {
-    "@pagopa/io-selfcare-subscription-migrations-sdk": "^1.3.3",
     "@pagopa/ts-commons": "^9.1.0",
     "@types/memoizee": "^0.4.2",
     "applicationinsights": "^1.0.3",

--- a/src/app.ts
+++ b/src/app.ts
@@ -311,7 +311,7 @@ if (config.IDP === "selfcare") {
         res.send(await result.text());
       } catch (error) {
         logger.error(
-          `Failte to proxy request to subscription migrations service`,
+          `Failed to proxy request to subscription migrations service`,
           error
         );
         res.status(500);

--- a/yarn.lock
+++ b/yarn.lock
@@ -204,15 +204,6 @@
     unified "^9.0.0"
     winston "^3.1.0"
 
-"@pagopa/io-selfcare-subscription-migrations-sdk@^1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-selfcare-subscription-migrations-sdk/-/io-selfcare-subscription-migrations-sdk-1.3.3.tgz#8c94d23566c2f06afc96ff4104a658c9395649a6"
-  integrity sha512-zZ67cH/5nbX0aKXDsoT3HO6vtMdVzitqF46589LfDCUH6u94FM8Ayy+oQV22uXYXyYOaMjHYr/WxxP5yOOGzxQ==
-  dependencies:
-    "@pagopa/ts-commons" "^10.0.0"
-    fp-ts "^2.10.5"
-    io-ts "^2.2.16"
-
 "@pagopa/openapi-codegen-ts@^9.0.0":
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/@pagopa/openapi-codegen-ts/-/openapi-codegen-ts-9.0.0.tgz#8b007959986a4d054195414f5822133bb40a9618"
@@ -226,20 +217,6 @@
     swagger-parser "^7.0.0"
     write-yaml-file "^4.1.3"
     yargs "^11.1.0"
-
-"@pagopa/ts-commons@^10.0.0":
-  version "10.2.1"
-  resolved "https://registry.yarnpkg.com/@pagopa/ts-commons/-/ts-commons-10.2.1.tgz#4d96fb041d66160602c8b07b61462a851427feca"
-  integrity sha512-41RSIP+AzyUBn8zZ/DHO/+4L8HrKn4MFbtGZp6H1XDeom78fWj2y+VtY53pGH3uORMqKhAKbMdggvPO+iqMAYg==
-  dependencies:
-    abort-controller "^3.0.0"
-    agentkeepalive "^4.1.4"
-    applicationinsights "^1.8.10"
-    fp-ts "^2.11.0"
-    io-ts "^2.2.16"
-    json-set-map "^1.1.2"
-    node-fetch "^2.6.0"
-    validator "^10.1.0"
 
 "@pagopa/ts-commons@^9.1.0":
   version "9.1.0"
@@ -617,15 +594,6 @@ agentkeepalive@^4.1.2:
     depd "^1.1.2"
     humanize-ms "^1.2.1"
 
-agentkeepalive@^4.1.4:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.2.0.tgz#616ce94ccb41d1a39a45d203d8076fe98713062d"
-  integrity sha512-0PhAp58jZNw13UJv7NVdTGb0ZcghHUb3DrZ046JiiJY/BOaTTpbwdHq2VObPCBV8M2GPh7sgrJ3AQ8Ey468LJw==
-  dependencies:
-    debug "^4.1.0"
-    depd "^1.1.2"
-    humanize-ms "^1.2.1"
-
 ajv@^6.5.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -697,16 +665,6 @@ applicationinsights@^1.7.3, applicationinsights@^1.7.4:
     continuation-local-storage "^3.2.1"
     diagnostic-channel "0.3.1"
     diagnostic-channel-publishers "0.4.1"
-
-applicationinsights@^1.8.10:
-  version "1.8.10"
-  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.8.10.tgz#fffa482cd1519880fb888536a87081ac05130667"
-  integrity sha512-ZLDA7mShh4mP2Z/HlFolmvhBPX1LfnbIWXrselyYVA7EKjHhri1fZzpu2EiWAmfbRxNBY6fRjoPJWbx5giKy4A==
-  dependencies:
-    cls-hooked "^4.2.2"
-    continuation-local-storage "^3.2.1"
-    diagnostic-channel "0.3.1"
-    diagnostic-channel-publishers "0.4.4"
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -1924,11 +1882,6 @@ diagnostic-channel-publishers@0.4.1:
   resolved "https://registry.yarnpkg.com/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.1.tgz#a1147ee0d5a4a06cd2b0795433bc1aee1dbc9801"
   integrity sha512-NpZ7IOVUfea/kAx4+ub4NIYZyRCSymjXM5BZxnThs3ul9gAKqjm7J8QDDQW3Ecuo2XxjNLoWLeKmrPUWKNZaYw==
 
-diagnostic-channel-publishers@0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.4.tgz#57c3b80b7e7f576f95be3a257d5e94550f0082d6"
-  integrity sha512-l126t01d2ZS9EreskvEtZPrcgstuvH3rbKy82oUhUrVmBaGx4hO9wECdl3cvZbKDYjMF3QJDB5z5dL9yWAjvZQ==
-
 diagnostic-channel-publishers@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.3.tgz#376b7798f4fa90f37eb4f94d2caca611b0e9c330"
@@ -2635,7 +2588,7 @@ forwarded@~0.1.2:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
-fp-ts@1.17.4, fp-ts@^1.0.0, fp-ts@^1.6.0, fp-ts@^2.10.5, fp-ts@^2.11.0:
+fp-ts@1.17.4, fp-ts@^1.0.0, fp-ts@^1.6.0:
   version "1.17.4"
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-1.17.4.tgz#f41eeeb2a8924b51b11521f93f5f59d28d0503be"
   integrity sha512-OaIM5w0FceJm6zO0OjMY05Rdg02nlFCpilTrMitzGnHORh/8neP0NH9OcRvnGQdOEh2T5xjtcutzzctvWOQtCQ==
@@ -3182,7 +3135,7 @@ io-functions-express@^0.1.1:
   resolved "https://registry.yarnpkg.com/io-functions-express/-/io-functions-express-0.1.1.tgz#6ae954fe89ec1d797c5e5d10eca5e77f08ff4a4d"
   integrity sha512-Co7sovRyB0lxgU6NFh5v72Apude3XbgKQtqA7slryvKoEqLAvlnLU7DtsYVoF62O3ZJdtSHYf9JWuhDc/di1mg==
 
-io-ts@1.8.5, io-ts@^1.1.4, io-ts@^2.2.16:
+io-ts@1.8.5, io-ts@^1.1.4:
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-1.8.5.tgz#2e102f7f518abe17b0f7e7ede0db54a4c4ddc188"
   integrity sha512-4HzDeg7mTygFjFIKh7ajBSanoVaFryYSFI0ocdwndSWl3eWQXhg3wVR0WI+Li5Vq11TIsoIngQszVbN4dy//9A==
@@ -4099,11 +4052,6 @@ json-set-map@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-set-map/-/json-set-map-1.0.2.tgz#608aacb5464d9759158d06523a6e30be5650adc4"
   integrity sha1-YIqstUZNl1kVjQZSOm4wvlZQrcQ=
-
-json-set-map@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/json-set-map/-/json-set-map-1.1.2.tgz#536cbc6549d06e8af11f76cb4fbd441ed2389e6e"
-  integrity sha512-x0TGwgcOG21jOa8wV1PWXDpSXUAKa1WuhMSHPBQhXU5Pb+4DdMrxOw5HMAWztVLP8KhSG5Kl5BoAOVF0aW63wA==
 
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"


### PR DESCRIPTION
As an extension of https://github.com/pagopa/io-developer-portal-backend/pull/159, it proxy **all** incoming requests to downstream service. The proxy acts as follow:
* authenticate the user to extract the organization they're working on behalf of
* rewrite paths from `/subscriptions/migrations/<path>` to `/organizations/<org_id>/<path>`  