### PR TITLE
[#IC-332] Fix APIM user creation for SelfCare accounts

### DIFF
--- a/src/apim_operations.ts
+++ b/src/apim_operations.ts
@@ -10,7 +10,8 @@ import {
   SubscriptionCollection,
   SubscriptionContract,
   UserContract,
-  UserCreateParameters
+  UserCreateParameters,
+  UserIdentityContract
 } from "azure-arm-apimanagement/lib/models";
 import { Set } from "json-set-map";
 import * as msRestAzure from "ms-rest-azure";
@@ -440,13 +441,13 @@ export async function createApimUserIfNotExists(
   apiClient: ApiManagementClient,
   {
     userEmail,
-    userAdId,
+    userIdentity,
     firstName,
     lastName,
     note = ""
   }: {
     readonly userEmail: EmailString;
-    readonly userAdId: string;
+    readonly userIdentity?: UserIdentityContract;
     readonly firstName: string;
     readonly lastName: string;
     readonly note?: string;
@@ -465,7 +466,7 @@ export async function createApimUserIfNotExists(
   logger.debug(
     "createApimUserIfNotExists|Creating new user (%s/%s)",
     userEmail,
-    userAdId
+    userIdentity?.id
   );
 
   try {
@@ -476,15 +477,11 @@ export async function createApimUserIfNotExists(
       {
         email: userEmail,
         firstName,
-        identities: [
-          {
-            id: userAdId,
-            provider: "AadB2C"
-          }
-        ],
         lastName,
         note,
-        state: "active"
+        state: "active",
+        // identity is optional
+        ...(userIdentity ? { identities: [userIdentity] } : {})
       }
     );
 

--- a/src/controllers/subscriptions.ts
+++ b/src/controllers/subscriptions.ts
@@ -33,6 +33,7 @@ import {
 } from "../utils/session";
 
 import { fromOption, isLeft } from "fp-ts/lib/Either";
+import { AdUser } from "../auth-strategies/azure_ad_strategy";
 import { getActualUser } from "../middlewares/actual_user";
 
 /**
@@ -101,8 +102,14 @@ export async function postSubscriptions(
             firstName: subscriptionData.new_user.first_name,
             lastName: subscriptionData.new_user.last_name,
             note: getApimAccountAnnotation(authenticatedUser),
-            userAdId: subscriptionData.new_user.adb2c_id,
-            userEmail: subscriptionData.new_user.email
+            userEmail: subscriptionData.new_user.email,
+            // for backwar compatibility, we link the active directory identity to the created apim user
+            userIdentity: AdUser.is(authenticatedUser)
+              ? {
+                  id: subscriptionData.new_user.adb2c_id,
+                  provider: "AadB2C"
+                }
+              : undefined
           })
         )
       : await getActualUser(apiClient, authenticatedUser, userEmail);


### PR DESCRIPTION
For historical reasons, when creating an APIM user we used to declare to which Active Directory identity the account has to be linked to. This holds for DevPortal, as we have one-on-one relation between APIM and AD accounts, but it does not for SelfCare IO, as the APIM account isn't related to the real person but to the Organization they are operating for.

This PR avoids to add such relation when running on `IDP=selfcare` mode. 

(we may have removed it anyway, as the relation is not actually used, but we decided to introduce the least possible change)