### PR TITLE
[#IOPAE-21] Create APIM account for Organizations when creating the session token

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -302,9 +302,10 @@ if (config.IDP === "selfcare") {
     "/idp/selfcare/resolve-identity",
     identityTokenVerifier,
     wrapRequestHandler(
-      withRequestMiddlewares(getSelfCareIdentityFromRequestMiddleware())(
-        resolveSelfCareIdentity
-      )
+      withRequestMiddlewares(
+        getSelfCareIdentityFromRequestMiddleware(),
+        getApiClientMiddleware()
+      )(resolveSelfCareIdentity)
     )
   );
 

--- a/src/auth-strategies/selfcare_identity_strategy.ts
+++ b/src/auth-strategies/selfcare_identity_strategy.ts
@@ -12,6 +12,19 @@ import { passportJwtSecret as fetchJwtSecret } from "jwks-rsa";
 import { ExtractJwt, Strategy as JwtStrategy } from "passport-jwt";
 import { JWT, processTokenInfo, UnixTime } from "./misc";
 
+export type SelfCareOrganization = t.TypeOf<typeof SelfCareOrganization>;
+export const SelfCareOrganization = t.interface({
+  fiscal_code: OrganizationFiscalCode,
+  id: NonEmptyString,
+  name: NonEmptyString,
+  roles: t.array(
+    t.interface({
+      partyRole: NonEmptyString,
+      role: NonEmptyString
+    })
+  )
+});
+
 /**
  *
  */
@@ -23,16 +36,7 @@ export const SelfCareIdentity = t.intersection([
     family_name: t.string,
     fiscal_number: FiscalCode,
     name: t.string,
-    organization: t.interface({
-      fiscal_code: OrganizationFiscalCode,
-      id: NonEmptyString,
-      roles: t.array(
-        t.interface({
-          partyRole: NonEmptyString,
-          role: NonEmptyString
-        })
-      )
-    })
+    organization: SelfCareOrganization
   })
 ]);
 

--- a/src/auth-strategies/selfcare_session_strategy.ts
+++ b/src/auth-strategies/selfcare_session_strategy.ts
@@ -7,11 +7,13 @@ import * as passport from "passport";
 import { ulid } from "ulid";
 
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
-import { OrganizationFiscalCode } from "@pagopa/ts-commons/lib/strings";
 import * as jwt from "jsonwebtoken";
 import { ExtractJwt, Strategy as JwtStrategy } from "passport-jwt";
 import { JWT, processTokenInfo } from "./misc";
-import { SelfCareIdentity } from "./selfcare_identity_strategy";
+import {
+  SelfCareIdentity,
+  SelfCareOrganization
+} from "./selfcare_identity_strategy";
 
 /**
  *
@@ -23,16 +25,7 @@ export const SelfCareUser = t.intersection([
     family_name: t.string,
     given_name: t.string,
     oid: NonEmptyString,
-    organization: t.interface({
-      fiscal_code: OrganizationFiscalCode,
-      id: NonEmptyString,
-      roles: t.array(
-        t.interface({
-          partyRole: NonEmptyString,
-          role: NonEmptyString
-        })
-      )
-    })
+    organization: SelfCareOrganization
   })
 ]);
 
@@ -86,11 +79,7 @@ export const createSessionToken = (
     iss: options.issuer,
     jti: ulid(),
     oid: data.fiscal_number,
-    organization: {
-      fiscal_code: data.organization.fiscal_code,
-      id: data.organization.id,
-      roles: data.organization.roles
-    },
+    organization: data.organization,
     sub: data.sub
   };
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about these changes' context. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
See commit list

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For `SelfCare` scenarios we want the APIM account to exist from the beginning. 
We think this to be a good thing by itself, but we also have a scenario that demands such a feature: 
> As an Organization which just moved from `DevPortal` to `SelfCare` we want to migrate the ownership of our existing services from our Delegates without creating any service ourselves.

This would not be possible with the current implementation as the APIM account (which holds all service-related subscriptions) is created lazily at the first service creation.

To do so, we create the APIM account for the Organization at the time we emit a session token (if it doesn't exists yet).

Should we do the same for `DevPortal` users (aka `Azure AD` scenarios)? It would be good, but in such a configuration, we don't have an explicit session token emission point (auth is evaluated against Active Directory at each request).


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
manually 🤗 

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
