### PR TITLE
[#IOPAE-68] Proxy requests for Delegates to `subsmigrations`

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -347,6 +347,8 @@ if (config.IDP === "selfcare") {
     }
   );
 } else if (config.IDP === "azure-ad") {
+  // The following utility retrieves APIM account id for the current authenticated user
+  // It does the job for this very specific use case, if needed in future we may think about moving it into common utils
   const getApimUserIdForLoggedUser = (
     req: express.Request
   ): Promise<Either<Error, string>> =>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
* Mount proxy `/subscriptions/migrations` for `IDP=azure-ad`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want Delegates to know if some subscriptions they own have been claimed by their Organizations. To do so, we need to proxy calls to the endpoint introduced in https://github.com/pagopa/io-subscription-migration/pull/48

Proxy is mounted for `IDP=azure-ad` only, that is it expects logged user to be a Delegate having its owns APIM account. Every request to `/subscriptions/migrations/<path>` is proxied to `<fn-subsmigrations>/delegates/<delegate-id>/<path>`.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
