### PR TITLE
[#IOPAE-103] Subscriptions pagination

### DIFF
--- a/src/apim_operations.ts
+++ b/src/apim_operations.ts
@@ -171,15 +171,23 @@ export const getUserSubscription = memoizee(getUserSubscription__, {
 export async function getUserSubscriptions(
   apiClient: ApiManagementClient,
   userId: string,
+  offset?: string,
+  limit?: string,
   lconfig: IApimConfig = config
 ): Promise<SubscriptionCollection> {
   logger.debug("getUserSubscriptions");
-  // TODO: this list is paginated with a next-link
-  // by now we get only the first result page
+
+  const options = {
+    top: limit ? +limit : undefined,
+    skip: offset ? +offset : undefined
+  };
+
+  // this list is paginated with a next-link
   return apiClient.userSubscription.list(
     lconfig.azurermResourceGroup,
     lconfig.azurermApim,
-    userId
+    userId,
+    options
   );
 }
 

--- a/src/apim_operations.ts
+++ b/src/apim_operations.ts
@@ -178,8 +178,8 @@ export async function getUserSubscriptions(
   logger.debug("getUserSubscriptions");
 
   const options = {
-    top: limit ? +limit : undefined,
-    skip: offset ? +offset : undefined
+    skip: offset ? +offset : undefined,
+    top: limit ? +limit : undefined
   };
 
   // this list is paginated with a next-link

--- a/src/apim_operations.ts
+++ b/src/apim_operations.ts
@@ -171,23 +171,21 @@ export const getUserSubscription = memoizee(getUserSubscription__, {
 export async function getUserSubscriptions(
   apiClient: ApiManagementClient,
   userId: string,
-  offset?: string,
-  limit?: string,
+  offset?: number,
+  limit?: number,
   lconfig: IApimConfig = config
 ): Promise<SubscriptionCollection> {
   logger.debug("getUserSubscriptions");
-
-  const options = {
-    skip: offset ? +offset : undefined,
-    top: limit ? +limit : undefined
-  };
 
   // this list is paginated with a next-link
   return apiClient.userSubscription.list(
     lconfig.azurermResourceGroup,
     lconfig.azurermApim,
     userId,
-    options
+    {
+      skip: offset,
+      top: limit
+    }
   );
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -65,6 +65,7 @@ import {
 } from "./middlewares/api_client";
 import { OptionalParamMiddleware } from "./middlewares/optional_param";
 import { RequiredParamMiddleware } from "./middlewares/required_param";
+import { OptionalQueryParamMiddleware } from "./middlewares/optional_query_param";
 import { getUserFromRequestMiddleware } from "./middlewares/user";
 
 import { SubscriptionData } from "./new_subscription";
@@ -148,7 +149,9 @@ app.get(
     withRequestMiddlewares(
       getApiClientMiddleware(),
       getUserFromRequestMiddleware(),
-      OptionalParamMiddleware("email", EmailString)
+      OptionalParamMiddleware("email", EmailString),
+      OptionalQueryParamMiddleware("offset", NonEmptyString),
+      OptionalQueryParamMiddleware("limit", NonEmptyString)
     )(getSubscriptions)
   )
 );

--- a/src/app.ts
+++ b/src/app.ts
@@ -83,6 +83,10 @@ import { resolveSelfCareIdentity } from "./controllers/idp";
 import { serviceData } from "./controllers/service_data";
 import { getSelfCareIdentityFromRequestMiddleware } from "./middlewares/idp";
 
+import {
+  IntegerFromString,
+  NonNegativeInteger
+} from "italia-ts-commons/lib/numbers";
 import { ProblemJson } from "italia-ts-commons/lib/responses";
 import { getApimUser } from "./apim_operations";
 import { getApimAccountEmail } from "./utils/session";
@@ -150,8 +154,14 @@ app.get(
       getApiClientMiddleware(),
       getUserFromRequestMiddleware(),
       OptionalParamMiddleware("email", EmailString),
-      OptionalQueryParamMiddleware("offset", NonEmptyString),
-      OptionalQueryParamMiddleware("limit", NonEmptyString)
+      OptionalQueryParamMiddleware(
+        "offset",
+        IntegerFromString.pipe(NonNegativeInteger)
+      ),
+      OptionalQueryParamMiddleware(
+        "limit",
+        IntegerFromString.pipe(NonNegativeInteger)
+      )
     )(getSubscriptions)
   )
 );

--- a/src/app.ts
+++ b/src/app.ts
@@ -64,8 +64,8 @@ import {
   getJiraClientMiddleware
 } from "./middlewares/api_client";
 import { OptionalParamMiddleware } from "./middlewares/optional_param";
-import { RequiredParamMiddleware } from "./middlewares/required_param";
 import { OptionalQueryParamMiddleware } from "./middlewares/optional_query_param";
+import { RequiredParamMiddleware } from "./middlewares/required_param";
 import { getUserFromRequestMiddleware } from "./middlewares/user";
 
 import { SubscriptionData } from "./new_subscription";

--- a/src/controllers/subscriptions.ts
+++ b/src/controllers/subscriptions.ts
@@ -43,7 +43,9 @@ import { getActualUser } from "../middlewares/actual_user";
 export async function getSubscriptions(
   apiClient: ApiManagementClient,
   authenticatedUser: SessionUser,
-  userEmail?: EmailString
+  userEmail?: EmailString,
+  offset?: NonEmptyString,
+  limit?: NonEmptyString
 ): Promise<
   | IResponseSuccessJson<SubscriptionCollection>
   | IResponseErrorForbiddenNotAuthorized
@@ -57,10 +59,12 @@ export async function getSubscriptions(
     return errorOrRetrievedApimUser.value;
   }
   const retrievedApimUser = errorOrRetrievedApimUser.value;
-
+  
   const subscriptions = await getUserSubscriptions(
     apiClient,
-    retrievedApimUser.name
+    retrievedApimUser.name,
+    offset,
+    limit
   );
   return ResponseSuccessJson(subscriptions);
 }

--- a/src/controllers/subscriptions.ts
+++ b/src/controllers/subscriptions.ts
@@ -33,6 +33,7 @@ import { subscribeApimUser, SubscriptionData } from "../new_subscription";
 import { getApimAccountEmail, SessionUser } from "../utils/session";
 
 import { fromOption, isLeft } from "fp-ts/lib/Either";
+import { NonNegativeInteger } from "italia-ts-commons/lib/numbers";
 import { AdUser } from "../auth-strategies/azure_ad_strategy";
 import { SelfCareUser } from "../auth-strategies/selfcare_session_strategy";
 import { getActualUser } from "../middlewares/actual_user";
@@ -44,8 +45,8 @@ export async function getSubscriptions(
   apiClient: ApiManagementClient,
   authenticatedUser: SessionUser,
   userEmail?: EmailString,
-  offset?: NonEmptyString,
-  limit?: NonEmptyString
+  offset?: NonNegativeInteger,
+  limit?: NonNegativeInteger
 ): Promise<
   | IResponseSuccessJson<SubscriptionCollection>
   | IResponseErrorForbiddenNotAuthorized

--- a/src/controllers/subscriptions.ts
+++ b/src/controllers/subscriptions.ts
@@ -59,7 +59,7 @@ export async function getSubscriptions(
     return errorOrRetrievedApimUser.value;
   }
   const retrievedApimUser = errorOrRetrievedApimUser.value;
-  
+
   const subscriptions = await getUserSubscriptions(
     apiClient,
     retrievedApimUser.name,

--- a/src/middlewares/optional_query_param.ts
+++ b/src/middlewares/optional_query_param.ts
@@ -1,0 +1,27 @@
+/**
+ * Middleware that extracts a typed optional query parameter from the HTTP request.
+ */
+import * as t from "io-ts";
+
+import { right } from "fp-ts/lib/Either";
+import { IRequestMiddleware } from "italia-ts-commons/lib/request_middleware";
+import {
+  IResponseErrorValidation,
+  ResponseErrorFromValidationErrors
+} from "italia-ts-commons/lib/responses";
+
+export function OptionalQueryParamMiddleware<S, A>(
+  name: string,
+  type: t.Type<A, S>
+): IRequestMiddleware<"IResponseErrorValidation", A | undefined> {
+  return async request => {
+    if (request.query[name] === undefined) {
+      return right(undefined);
+    }
+    return type
+      .decode(request.query[name])
+      .mapLeft<IResponseErrorValidation>(
+        ResponseErrorFromValidationErrors(type)
+      );
+  };
+}


### PR DESCRIPTION
**Added pagination capability to user's subscription list**
Now is possible to specify *limit* and *offset* query parameters to *subscriptions* GET method.

#### List of Changes
<!--- Describe your changes in detail -->
- Add *OptionalQueryParam* middleware implementation
- Add optional *offset* and *limit* query params to **subscriptions** *GET* method

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Before the changes, all subscriptions were loaded all at once and this could create loading problems for users with many subscriptions *(cases with thousands of subscriptions)*.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
**Integration Tests with developer-portal-frontend**
*(Tested with 16 user’s subscriptions available account)*
- **limit=20**
    - offset=0 limit=20 —> OK Load One Shot, button “Carica altri servizi” is hidden
-  **limit=8**
    - offset=0 limit=8 —> OK Load first page, button “Carica altri servizi” is visible
    - offset=8 limit=8 —> OK Caricamento seconda pagina, tasto “Carica altri servizi” hidden
- **limit=5**
    - offset=0  —> OK Load first page, button “Carica altri servizi” is visible
    - offset=5  —> OK Load second page, button “Carica altri servizi” is visible
    - offset=10 —> OK Load third page, button “Carica altri servizi” is visible
    - offset=15 —> OK Load forth page, button “Carica altri servizi” is hidden

**Backend non regression**
- [x] Get subscriptions without offset & limit query params —> STATUS CODE 200 OK, all 16 subscriptions returned

**Backend edge cases**
- [x] Get subscriptions without offset, with limit=20 query params —> STATUS CODE 200 OK, all 16 subscriptions returned
- [x] Get subscriptions without offset, with limit=5 query params —> STATUS CODE 200 OK, first 5 subscriptions returned
- [x] Get subscriptions with offset=0, without limit query params —> STATUS CODE 200 OK, all 16 subscriptions returned
- [x] Get subscriptions with offset=5, without limit query params —> STATUS CODE 200 OK, last 11 subscriptions returned
- [x] Get subscriptions with offset=50, without limit query params —> STATUS CODE 200 OK, no subscriptions returned
- [x] Get subscriptions without offset, with invalid limit=abc query params —> STATUS CODE 400 (Bad Request)
- [x] Get subscriptions with invalid offset=abc, without limit query params —> STATUS CODE 400 (Bad Request)
- [x] Get subscriptions with negative offset=-5, without limit query params —> STATUS CODE 400 (Bad Request)

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
