### PR TITLE
Replace danger-ci with github-action in pipeline

### DIFF
--- a/.devops/code-review-pipelines.yml
+++ b/.devops/code-review-pipelines.yml
@@ -56,16 +56,6 @@ stages:
             npx oval validate -p definitions.yaml
           displayName: 'Validate definitions specification'
 
-      - job: danger
-        condition: ne(variables['DANGER_GITHUB_API_TOKEN'], 'skip')
-        steps:
-          - template: templates/node-job-setup/template.yaml@pagopaCommons
-          - bash: |
-              yarn danger ci
-            env:
-              DANGER_GITHUB_API_TOKEN: '$(DANGER_GITHUB_API_TOKEN)'
-            displayName: 'Danger CI'
-
   - stage: Test
     dependsOn: []
     jobs:

--- a/.github/workflows/pr-title-linter-and-linker.yaml
+++ b/.github/workflows/pr-title-linter-and-linker.yaml
@@ -1,0 +1,82 @@
+name: "Lint and Link PR title"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  lint:
+    name: Validate PR title And link Jira Issue
+    runs-on: ubuntu-22.04
+    env:
+      JIRA_COMMENT_REGEX: "^.*Jira.*"
+    steps:
+      - uses: Slashgear/action-check-pr-title@860e8dc639f8e60335a6f5e8936ba67ed2536890
+        id: lint
+        with:
+          regexp: "\\[(#?[A-Z]*-[0-9]*( |, )?){1,}\\]" # Regex the title should match.
+        continue-on-error: true
+
+      - name: Find Jira Comment
+        uses: peter-evans/find-comment@81e2da3af01c92f83cb927cf3ace0e085617c556
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-regex: "${{ env.JIRA_COMMENT_REGEX }}"
+
+      - name: Extract Jira Issue to Link
+        id: extract_jira_issue
+        if: steps.lint.outcome == 'success'
+        run: |
+          PR_TITLE=$(echo "${{ github.event.pull_request.title }}")
+          ISSUES_STR=$(awk -F'\\[|\\]' '{print $2}' <<< "$PR_TITLE" | sed "s/#//g" | sed "s/,//g")
+          ISSUES=($ISSUES_STR)
+          JIRA_ISSUE=$(echo ${ISSUES_STR##* })
+          MARKDOWN_CARRIAGE_RETURN="<br>"
+          MARKDOWN_PREFIX="- Link to"
+          JIRA_COMMENT_MARKDOWN="This Pull Request refers to Jira issues:<br>"
+          if [[ ${#ISSUES[@]} -eq 1 ]]
+          then
+            JIRA_COMMENT_MARKDOWN="This Pull Request refers to the following Jira issue"
+            MARKDOWN_PREFIX=""
+          fi
+
+          for ISSUE in "${ISSUES[@]}"
+          do
+            JIRA_COMMENT_MARKDOWN+="$MARKDOWN_PREFIX [$ISSUE](https://pagopa.atlassian.net/browse/$ISSUE) $MARKDOWN_CARRIAGE_RETURN"
+          done
+
+          echo "JIRA_ISSUE=$JIRA_ISSUE" >> $GITHUB_ENV
+          echo "JIRA_COMMENT_MARKDOWN=$JIRA_COMMENT_MARKDOWN" >> $GITHUB_ENV
+      
+      - name: Create Jira Link comment
+        if: steps.lint.outcome == 'success'
+        uses: peter-evans/create-or-update-comment@5adcb0bb0f9fb3f95ef05400558bdb3f329ee808
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## Jira Pull Request Link ##
+            ${{ env.JIRA_COMMENT_MARKDOWN }}
+          edit-mode: replace
+      - name: Create Empty Jira Link comment
+        if: steps.lint.outcome != 'success'
+        uses: peter-evans/create-or-update-comment@5adcb0bb0f9fb3f95ef05400558bdb3f329ee808
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## Jira Pull request Link ##
+            It seems this Pull Request has no issues that refers to Jira!!!
+            Please check it out.
+          edit-mode: replace
+      - name: Failure message
+        if: steps.lint.outcome != 'success'
+        run: |
+          echo "Pull request title (${{ github.event.pull_request.title }}) is not properly formatted or it is not related to any Jira issue"
+          exit 1


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Replace Danger CI with a Github Action in Azure pipeline code review

#### List of Changes
<!--- Describe your changes in detail -->
- Remove *danger-ci* from *.devops/code-review-pipelines.yml*
- Add new Github Action *pr-title-linter-and-linker.yaml*

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
