### PR TITLE
[IOPAE-459] Lock Selfcare new user to create new Apim user

### DIFF
--- a/src/apim_operations.ts
+++ b/src/apim_operations.ts
@@ -564,6 +564,13 @@ export async function createApimUserIfNotExists(
   if (isSome(maybeExistingApimUser)) {
     return maybeExistingApimUser;
   }
+  // feature flag to temporarily block the creation of new APIM users
+  if (config.lockSelfcareCreateNewApimUser) {
+    logger.debug(
+      "createApimUserIfNotExists|Creating new user locked by config"
+    );
+    return none;
+  }
 
   logger.debug(
     "createApimUserIfNotExists|Creating new user (%s/%s)",

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ import { errorsToReadableMessages } from "italia-ts-commons/lib/reporters";
 import { FiscalCode, NonEmptyString } from "italia-ts-commons/lib/strings";
 
 import { EmailAddress } from "../generated/api/EmailAddress";
+import { BooleanFromString } from "./utils/booleans";
 import { CommaSeparatedListOf } from "./utils/comma-separated-list";
 
 /**
@@ -238,5 +239,19 @@ export const manageFlowEnableUserList = withDefault(
   .getOrElseL(_ => {
     throw new Error(
       `Invalid Manage Flow enable user list configured: ${process.env.MANAGE_FLOW_ENABLE_USER_LIST}`
+    );
+  });
+
+/**
+ * Lock the creation of a new APIM user, when resolve SelfCareIdentity.
+ */
+export const lockSelfcareCreateNewApimUser = withDefault(
+  BooleanFromString,
+  ("false" as unknown) as boolean
+)
+  .decode(process.env.LOCK_SELFCARE_CREATE_NEW_APIM_USER)
+  .getOrElseL(_ => {
+    throw new Error(
+      `Invalid lockSelfcareCreateNewApimUser configured: ${process.env.LOCK_SELFCARE_CREATE_NEW_APIM_USER}`
     );
   });

--- a/src/controllers/idp.ts
+++ b/src/controllers/idp.ts
@@ -2,6 +2,7 @@ import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { ValidUrl } from "@pagopa/ts-commons/lib/url";
 import ApiManagementClient from "azure-arm-apimanagement";
+import { isNone } from "fp-ts/lib/Option";
 import * as t from "io-ts";
 import {
   IResponsePermanentRedirect,
@@ -17,7 +18,6 @@ import { createSessionToken } from "../auth-strategies/selfcare_session_strategy
 import { selfcareSessionCreds } from "../config";
 import * as config from "../config";
 import { logger } from "../logger";
-import { isNone } from "fp-ts/lib/Option";
 
 const withToken = (url: ValidUrl, idToken: string): ValidUrl => {
   const newUrl = `${url.href}#id_token=${idToken}`;

--- a/src/utils/__tests__/booleans.test.ts
+++ b/src/utils/__tests__/booleans.test.ts
@@ -1,0 +1,27 @@
+/* eslint-disable sonarjs/no-identical-functions */
+
+import { isLeft, isRight } from "fp-ts/lib/Either";
+import { BooleanFromString } from "../booleans";
+
+describe("BooleanFromString", () => {
+  it("should get boolean true from string 'true'", async () => {
+    const n = BooleanFromString.decode("true");
+    expect(isRight(n)).toBeTruthy();
+    if (isRight(n)) {
+      expect(n.value).toEqual(true);
+    }
+  });
+
+  it("should get boolean false from string 'false'", async () => {
+    const n = BooleanFromString.decode("false");
+    expect(isRight(n)).toBeTruthy();
+    if (isRight(n)) {
+      expect(n.value).toEqual(false);
+    }
+  });
+
+  it("should get error from string 'astring'", () => {
+    const n = BooleanFromString.decode("astring");
+    expect(isLeft(n)).toBeTruthy();
+  });
+});

--- a/src/utils/booleans.ts
+++ b/src/utils/booleans.ts
@@ -1,0 +1,19 @@
+import * as t from "io-ts";
+
+export type BooleanFromString = t.Type<boolean, string, unknown>;
+
+export const BooleanFromString: BooleanFromString = new t.Type<
+  boolean,
+  string,
+  unknown
+>(
+  "BooleanFromString",
+  t.boolean.is,
+  (s, c) =>
+    s === "true"
+      ? t.success(true)
+      : s === "false"
+      ? t.success(false)
+      : t.failure(s, c),
+  String
+);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Introduced the ability to block for a _**new Selfcare user**_ _(a user who has never accessed the Developer Portal)_, to access to Developer Portal.
This possibility can be activated using the boolean `LOCK_SELFCARE_CREATE_NEW_APIM_USER` feature flag, deactivated _(false)_ by default.

#### List of Changes
<!--- Describe your changes in detail -->
- added `BooleanFromString` codec
- added boolean feature flag `LOCK_SELFCARE_CREATE_NEW_APIM_USER`
- added logic to lock the creation of new Apim User based of feature flag activation

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For maintenance needs on **Azure API Management** _(APIM)_, a feature has been developed to block the creation/update of new APIM users.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
